### PR TITLE
Cross search cleanup

### DIFF
--- a/backend/src/routes/crossSearch.ts
+++ b/backend/src/routes/crossSearch.ts
@@ -1,5 +1,4 @@
 import { Router } from 'express'
-import { getLocalityDetails } from '../services/locality'
 import { getAllCrossSearch } from '../services/crossSearch'
 import { fixBigInt } from '../utils/common'
 
@@ -8,13 +7,6 @@ const router = Router()
 router.get('/all', async (req, res) => {
   const crossSearch = await getAllCrossSearch(req.user)
   return res.status(200).send(fixBigInt(crossSearch))
-})
-
-router.get('/:id', async (req, res) => {
-  const id = parseInt(req.params.id)
-  const locality = await getLocalityDetails(id, req.user)
-  if (!locality) return res.status(404).send()
-  return res.status(200).send(fixBigInt(locality))
 })
 
 export default router

--- a/backend/src/services/crossSearch.ts
+++ b/backend/src/services/crossSearch.ts
@@ -67,7 +67,6 @@ export const getAllCrossSearch = async (user?: User) => {
   const removeProjects: (loc: CrossSearchListType) => Omit<CrossSearchListType, 'now_plr'> = loc => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { now_plr, ...rest } = loc
-    // console.log(loc)
     return rest
   }
 

--- a/frontend/src/components/CrossSearch/CrossSearchTable.tsx
+++ b/frontend/src/components/CrossSearch/CrossSearchTable.tsx
@@ -1,14 +1,11 @@
 import { useMemo } from 'react'
 import { type MRT_ColumnDef } from 'material-react-table'
-import { useGetAllCrossSearchQuery, useGetCrossSearchListMutation } from '../../redux/crossSearchReducer'
+import { useGetAllCrossSearchQuery } from '../../redux/crossSearchReducer'
 import { CrossSearch } from '@/backendTypes'
 import { TableView } from '../TableView/TableView'
-import { useNotify } from '@/hooks/notification'
 
 export const CrossSearchTable = ({ selectorFn }: { selectorFn?: (newObject: CrossSearch) => void }) => {
   const CrossSearchQuery = useGetAllCrossSearchQuery()
-  const [getCrossSearchList, { isLoading }] = useGetCrossSearchListMutation()
-  const notify = useNotify()
   const columns = useMemo<MRT_ColumnDef<CrossSearch>[]>(
     () => [
       {
@@ -84,27 +81,6 @@ export const CrossSearchTable = ({ selectorFn }: { selectorFn?: (newObject: Cros
     []
   )
 
-  const combinedExport = async (lids: number[]) => {
-    if (isLoading) {
-      notify('Please wait for the last request to complete.', 'warning')
-      return
-    }
-
-    const limit = 99999999
-    if (lids.length > limit) {
-      notify(`Please filter the table more. Current rows: ${lids.length}. Limit: ${limit}`, 'error')
-      return
-    }
-    const result = await getCrossSearchList(lids).unwrap()
-    const dataString = result.map(row => row.join(',')).join('\n')
-    const blob = new Blob([dataString], { type: 'text/csv' })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = 'localitiesWithSpecies.csv'
-    a.click()
-  }
-
   const checkRowRestriction = (row: CrossSearch) => {
     return !!row.loc_status
   }
@@ -118,8 +94,6 @@ export const CrossSearchTable = ({ selectorFn }: { selectorFn?: (newObject: Cros
       columns={columns}
       data={CrossSearchQuery.data}
       url="crosssearch"
-      combinedExport={combinedExport}
-      exportIsLoading={isLoading}
     />
   )
 }

--- a/frontend/src/components/CrossSearch/CrossSearchTable.tsx
+++ b/frontend/src/components/CrossSearch/CrossSearchTable.tsx
@@ -87,7 +87,7 @@ export const CrossSearchTable = ({ selectorFn }: { selectorFn?: (newObject: Cros
 
   return (
     <TableView<CrossSearch>
-      title="Locality-Species-Cross-Search (UNDER CONSTRUCTION)"
+      title="Locality-Species-Cross-Search"
       selectorFn={selectorFn}
       checkRowRestriction={checkRowRestriction}
       idFieldName="lid"

--- a/frontend/src/redux/crossSearchReducer.ts
+++ b/frontend/src/redux/crossSearchReducer.ts
@@ -9,14 +9,7 @@ const crossSearchApi = api.injectEndpoints({
       }),
       providesTags: result => (result ? [{ type: 'localities' }] : []),
     }),
-    getCrossSearchList: builder.mutation<string[][], number[]>({
-      query: (lids: number[]) => ({
-        url: `/locality-species`,
-        body: { lids },
-        method: 'POST',
-      }),
-    }),
   }),
 })
 
-export const { useGetAllCrossSearchQuery, useGetCrossSearchListMutation } = crossSearchApi
+export const { useGetAllCrossSearchQuery } = crossSearchApi


### PR DESCRIPTION
Did a small patch of cleanup. Removed code I had copypasted from locality view. I figured that the csv-table for cross-search does not need a special export. The export table -button prints a nice clean .csv