### PR TITLE
somehow optimised it to take 10ms longer, but the code is cleaner

### DIFF
--- a/backend/src/services/crossSearch.ts
+++ b/backend/src/services/crossSearch.ts
@@ -23,32 +23,6 @@ type CrossSearchListType = {
   now_plr: {
     pid: number
   }[]
-  now_ls: {
-    com_species: {
-      species_id: number
-      subclass_or_superorder_name: string | null
-      order_name: string
-      suborder_or_superfamily_name: string | null
-      family_name: string
-      subfamily_name: string | null
-      genus_name: string
-      species_name: string
-      unique_identifier: string
-      taxonomic_status: string
-      sp_status: boolean | null
-    }
-  }[]
-}
-
-type CrossSearchListTypeCleaned = {
-  lid: number
-  bfa_max: string | null
-  bfa_min: string | null
-  loc_name: string
-  max_age: number
-  min_age: number
-  country: string | null
-  loc_status: boolean | null
   species_id: number
   subclass_or_superorder_name: string | null
   order_name: string
@@ -70,89 +44,78 @@ export const getAllCrossSearch = async (user?: User) => {
     return rest
   }
 
-  const result = (await nowDb.now_loc.findMany({
+  const queryResult = await nowDb.now_ls.findMany({
     select: {
-      lid: true,
-      //columns from now_loc
-      loc_name: true,
-      bfa_max: true,
-      bfa_min: true,
-      max_age: true,
-      min_age: true,
-      country: true,
-      loc_status: true,
-      now_plr: {
-        select: { pid: true },
-      },
-      now_ls: {
+      now_loc: {
         select: {
-          com_species: {
-            select: {
-              //columns from com_species
-              species_id: true,
-              subclass_or_superorder_name: true,
-              order_name: true,
-              suborder_or_superfamily_name: true,
-              family_name: true,
-              subfamily_name: true,
-              genus_name: true,
-              species_name: true,
-              unique_identifier: true,
-              taxonomic_status: true,
-              sp_status: true,
-            },
+          lid: true,
+          loc_name: true,
+          bfa_max: true,
+          bfa_min: true,
+          max_age: true,
+          min_age: true,
+          country: true,
+          loc_status: true,
+          now_plr: {
+            select: { pid: true },
           },
         },
       },
+      com_species: {
+        select: {
+          species_id: true,
+          subclass_or_superorder_name: true,
+          order_name: true,
+          suborder_or_superfamily_name: true,
+          family_name: true,
+          subfamily_name: true,
+          genus_name: true,
+          species_name: true,
+          unique_identifier: true,
+          taxonomic_status: true,
+          sp_status: true,
+        },
+      },
     },
+  })
+
+  const flattenedResult = queryResult.map(item => ({
+    lid: item.now_loc.lid,
+    loc_name: item.now_loc.loc_name,
+    bfa_max: item.now_loc.bfa_max,
+    bfa_min: item.now_loc.bfa_min,
+    max_age: item.now_loc.max_age,
+    min_age: item.now_loc.min_age,
+    country: item.now_loc.country,
+    loc_status: item.now_loc.loc_status,
+    now_plr: item.now_loc.now_plr,
+    species_id: item.com_species.species_id,
+    subclass_or_superorder_name: item.com_species.subclass_or_superorder_name,
+    order_name: item.com_species.order_name,
+    suborder_or_superfamily_name: item.com_species.suborder_or_superfamily_name,
+    family_name: item.com_species.family_name,
+    subfamily_name: item.com_species.subfamily_name,
+    genus_name: item.com_species.genus_name,
+    species_name: item.com_species.species_name,
+    unique_identifier: item.com_species.unique_identifier,
+    taxonomic_status: item.com_species.taxonomic_status,
+    sp_status: item.com_species.sp_status,
   })) as CrossSearchListType[]
 
-  const cleanResults = (result: Omit<CrossSearchListType, 'now_plr'>[]) => {
-    const cleanedResult: CrossSearchListTypeCleaned[] = []
-    result.forEach(loc => {
-      loc.now_ls.forEach(species => {
-        cleanedResult.push({
-          lid: loc.lid,
-          loc_name: loc.loc_name,
-          bfa_max: loc.bfa_max,
-          bfa_min: loc.bfa_min,
-          max_age: loc.max_age,
-          min_age: loc.min_age,
-          country: loc.country,
-          loc_status: loc.loc_status,
-          species_id: species.com_species.species_id,
-          subclass_or_superorder_name: species.com_species.subclass_or_superorder_name,
-          order_name: species.com_species.order_name,
-          suborder_or_superfamily_name: species.com_species.suborder_or_superfamily_name,
-          family_name: species.com_species.family_name,
-          subfamily_name: species.com_species.subfamily_name,
-          genus_name: species.com_species.genus_name,
-          species_name: species.com_species.species_name,
-          unique_identifier: species.com_species.unique_identifier,
-          taxonomic_status: species.com_species.taxonomic_status,
-          sp_status: species.com_species.sp_status,
-        })
-      })
-    })
-
-    return cleanedResult
-  }
-
   if (showAll) {
-    const cleanedResult = cleanResults(result.map(removeProjects))
-    return cleanedResult
+    const result = flattenedResult.map(removeProjects)
+    return result
   }
   if (!user) {
-    const cleanedResult = cleanResults(result.filter(loc => loc.loc_status === false).map(removeProjects))
-    return cleanedResult
+    const result = flattenedResult.filter(loc => loc.loc_status === false).map(removeProjects)
+    return result
   }
 
   const usersProjects = await getIdsOfUsersProjects(user)
 
-  const cleanedResult = cleanResults(
-    result
-      .filter(loc => !loc.loc_status || loc.now_plr.find(now_plr => usersProjects.has(now_plr.pid)))
-      .map(removeProjects)
-  )
-  return cleanedResult
+  const result = flattenedResult
+    .filter(loc => !loc.loc_status || loc.now_plr.find(now_plr => usersProjects.has(now_plr.pid)))
+    .map(removeProjects)
+
+  return result
 }


### PR DESCRIPTION
The code is (in my eyes) less messy and produces the same results (in different order). It used to query for a list of nested objects (localities with species inside) then loop all localities and species within them to produce a list of locality-species-pairings. Now it queries a list of locality-species-pair-objects ({loc:{...}, spec{...}}) and maps it to single flattened object. The warning comes from a single middleware (SerializableStateInvariantMiddleware) that states it took 214ms (warning threshold being 128ms). Before it was 204ms on my pc. I'm beginning to think it just takes this much because there's >5000 pages of results for the table and this is a middleware for redux-toolkit