### PR TITLE
Species validators v2

### DIFF
--- a/backend/src/api-tests/species/create.test.ts
+++ b/backend/src/api-tests/species/create.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, beforeAll, afterAll, describe, it, expect } from '@jest/globals'
 import { LocalityDetailsType, SpeciesDetailsType } from '../../../../frontend/src/backendTypes'
 import { LogRow } from '../../services/write/writeOperations/types'
-import { newSpeciesBasis } from './data'
+import { newSpeciesBasis, newSpeciesWithoutRequiredFields } from './data'
 import { login, resetDatabase, send, testLogRows } from '../utils'
 import { pool } from '../../utils/db'
 
@@ -54,5 +54,12 @@ describe('Creating new species works', () => {
       },
     ]
     testLogRows(logRows, expectedLogRows, 2)
+  })
+
+  it('Species without required fields fails', async () => {
+    const res = await send('species', 'PUT', {
+      species: { ...newSpeciesWithoutRequiredFields, comment: 'species test' },
+    })
+    expect(res.status).toEqual(400)
   })
 })

--- a/backend/src/api-tests/species/create.test.ts
+++ b/backend/src/api-tests/species/create.test.ts
@@ -19,10 +19,10 @@ describe('Creating new species works', () => {
   })
 
   it('Request succeeds and returns valid number id', async () => {
-    const { body: resultBody } = await send<{ id: number }>('species', 'PUT', {
+    const { body: resultBody } = await send<{ species_id: number }>('species', 'PUT', {
       species: { ...newSpeciesBasis, comment: 'species test' },
     })
-    const { id: createdId } = resultBody
+    const { species_id: createdId } = resultBody
 
     expect(typeof createdId).toEqual('number') // `Invalid result returned on write: ${createdId}`
 

--- a/backend/src/api-tests/species/data.ts
+++ b/backend/src/api-tests/species/data.ts
@@ -116,3 +116,11 @@ export const editedSpecies: EditDataType<SpeciesDetailsType & EditMetaData> = {
   comment: 'species edit test',
   references: [{ rid: 24188 } as Reference],
 }
+
+export const newSpeciesWithoutRequiredFields: EditDataType<SpeciesDetailsType> = {
+  ...newSpeciesBasis,
+  order_name: '',
+  family_name: '',
+  genus_name: '',
+  species_name: '',
+}

--- a/backend/src/api-tests/species/update.test.ts
+++ b/backend/src/api-tests/species/update.test.ts
@@ -19,11 +19,11 @@ describe('Updating species works', () => {
   })
 
   it('Edits name, comment and locality-species correctly', async () => {
-    const writeResult = await send<{ id: number }>('species', 'PUT', { species: editedSpecies })
+    const writeResult = await send<{ species_id: number }>('species', 'PUT', { species: editedSpecies })
     expect(writeResult.status).toEqual(200) // 'Response status was OK'
-    expect(writeResult.body.id).toEqual(editedSpecies.species_id) // `Invalid result returned on write: ${writeResult.body.id}`
+    expect(writeResult.body.species_id).toEqual(editedSpecies.species_id) // `Invalid result returned on write: ${writeResult.body.id}`
 
-    const { body, status } = await send<SpeciesDetailsType>(`species/${writeResult.body.id}`, 'GET')
+    const { body, status } = await send<SpeciesDetailsType>(`species/${writeResult.body.species_id}`, 'GET')
     expect(status).toEqual(200) // 'Status on response to GET added species request was OK'
     editedSpeciesResult = body
   })

--- a/backend/src/routes/species.ts
+++ b/backend/src/routes/species.ts
@@ -29,8 +29,8 @@ router.put(
     if (validationErrors.length > 0) {
       return res.status(400).send()
     }
-    const id = await writeSpecies(editedSpecies, comment, references, req.user!.initials)
-    return res.status(200).send({ id })
+    const species_id = await writeSpecies(editedSpecies, comment, references, req.user!.initials)
+    return res.status(200).send({ species_id })
   }
 )
 

--- a/backend/src/routes/species.ts
+++ b/backend/src/routes/species.ts
@@ -1,5 +1,5 @@
 import { Request, Router } from 'express'
-import { getAllSpecies, getSpeciesDetails } from '../services/species'
+import { getAllSpecies, getSpeciesDetails, validateEntireSpecies } from '../services/species'
 import { fixBigInt } from '../utils/common'
 import { EditMetaData, SpeciesDetailsType } from '../../../frontend/src/backendTypes'
 import { deleteSpecies, writeSpecies } from '../services/write/species'
@@ -25,6 +25,10 @@ router.put(
   requireOneOf([Role.Admin, Role.EditUnrestricted]),
   async (req: Request<object, object, { species: SpeciesDetailsType & EditMetaData }>, res) => {
     const { comment, references, ...editedSpecies } = req.body.species
+    const validationErrors = validateEntireSpecies(editedSpecies)
+    if (validationErrors.length > 0) {
+      return res.status(400).send()
+    }
     const id = await writeSpecies(editedSpecies, comment, references, req.user!.initials)
     return res.status(200).send({ id })
   }

--- a/backend/src/services/species.ts
+++ b/backend/src/services/species.ts
@@ -1,4 +1,7 @@
-import { SpeciesDetailsType } from '../../../frontend/src/backendTypes'
+import { EditDataType, SpeciesDetailsType } from '../../../frontend/src/backendTypes'
+import { validateSpecies } from '../../../frontend/src/validators/species'
+import { ValidationObject } from '../../../frontend/src/validators/validator'
+import Prisma from '../../prisma/generated/now_test_client'
 import { fixBigInt } from '../utils/common'
 import { logDb, nowDb } from '../utils/db'
 
@@ -68,4 +71,14 @@ export const getSpeciesDetails = async (id: number) => {
   }))
 
   return JSON.parse(fixBigInt({ ...result, com_taxa_synonym: synonyms || [] })!) as SpeciesDetailsType
+}
+
+export const validateEntireSpecies = (editedFields: EditDataType<Prisma.com_species>) => {
+  const keys = Object.keys(editedFields)
+  const errors: ValidationObject[] = []
+  for (const key of keys) {
+    const error = validateSpecies(editedFields as EditDataType<SpeciesDetailsType>, key as keyof SpeciesDetailsType)
+    if (error.error) errors.push(error)
+  }
+  return errors
 }

--- a/cypress/e2e/species.cy.js
+++ b/cypress/e2e/species.cy.js
@@ -1,0 +1,25 @@
+describe("Species validators work", () => {
+    beforeEach('Login as admin', () => {
+        cy.login('testSu')
+    })
+
+    it.skip("Creating a species with missing required fields does not work", () => {
+        cy.visit('/species/new')
+        cy.contains("This field is required")
+        cy.get('[id=write-button]').click()
+        cy.get('[id=write-button]').click()
+        cy.contains("This field is required")
+    })
+
+    it.skip("Creating a species with valid data works", () => {
+        cy.visit('/species/new')
+        cy.get('[id=order]').type('testOrder')
+        cy.get('[id=family]').type('testFamily')
+        cy.get('[id=genus]').type('testGenus')
+        cy.get('[id=species]').type('testSpecies')
+        cy.get('[id=write-button]').click()
+        cy.get('[id=write-button]').click()
+        cy.contains('testOrder')
+    })
+        
+})

--- a/frontend/src/components/Species/SpeciesDetails.tsx
+++ b/frontend/src/components/Species/SpeciesDetails.tsx
@@ -49,7 +49,9 @@ export const SpeciesDetails = () => {
   }
 
   const onWrite = async (editData: EditDataType<SpeciesDetailsType>) => {
-    await editSpeciesRequest(editData)
+    console.log(editData)
+    const { species_id } = await editSpeciesRequest(editData).unwrap()
+    navigate(`/species/${species_id}`)
   }
 
   const tabs: TabType[] = [

--- a/frontend/src/components/Species/SpeciesDetails.tsx
+++ b/frontend/src/components/Species/SpeciesDetails.tsx
@@ -50,7 +50,7 @@ export const SpeciesDetails = () => {
 
   const onWrite = async (editData: EditDataType<SpeciesDetailsType>) => {
     const { species_id } = await editSpeciesRequest(editData).unwrap()
-    setTimeout (() => navigate(`/species/${species_id}`), 15)
+    setTimeout(() => navigate(`/species/${species_id}`), 15)
   }
 
   const tabs: TabType[] = [

--- a/frontend/src/components/Species/SpeciesDetails.tsx
+++ b/frontend/src/components/Species/SpeciesDetails.tsx
@@ -23,8 +23,8 @@ export const SpeciesDetails = () => {
   if (isNew) {
     document.title = 'New species'
   }
-  const { isLoading, isError, isFetching, data } = useGetSpeciesDetailsQuery(id!, { skip: isNew })
-  const [editSpeciesRequest] = useEditSpeciesMutation()
+  const [editSpeciesRequest, { isLoading: mutationLoading }] = useEditSpeciesMutation()
+  const { isError, isFetching, data } = useGetSpeciesDetailsQuery(id!, { skip: isNew })
   const notify = useNotify()
   const navigate = useNavigate()
   const [deleteMutation, { isSuccess: deleteSuccess, isError: deleteError }] = useDeleteSpeciesMutation()
@@ -39,7 +39,7 @@ export const SpeciesDetails = () => {
   }, [deleteSuccess, deleteError, notify, navigate])
 
   if (isError) return <div>Error loading data</div>
-  if (isLoading || isFetching || (!data && !isNew)) return <CircularProgress />
+  if (isFetching || (!data && !isNew) || mutationLoading) return <CircularProgress />
   if (data) {
     document.title = `Species - ${data.species_name}`
   }
@@ -49,7 +49,6 @@ export const SpeciesDetails = () => {
   }
 
   const onWrite = async (editData: EditDataType<SpeciesDetailsType>) => {
-    console.log(editData)
     const { species_id } = await editSpeciesRequest(editData).unwrap()
     navigate(`/species/${species_id}`)
   }

--- a/frontend/src/components/Species/SpeciesDetails.tsx
+++ b/frontend/src/components/Species/SpeciesDetails.tsx
@@ -50,7 +50,7 @@ export const SpeciesDetails = () => {
 
   const onWrite = async (editData: EditDataType<SpeciesDetailsType>) => {
     const { species_id } = await editSpeciesRequest(editData).unwrap()
-    navigate(`/species/${species_id}`)
+    setTimeout (() => navigate(`/species/${species_id}`), 15)
   }
 
   const tabs: TabType[] = [


### PR DESCRIPTION
This time working I hope.

Had to switch 'id' to 'species_id' in back end responses to work with current frontend and not touching backendtypes. Also some twiddling with some frontend logic to mimic localitys front end logic. Also needed to add a 15ms time-out to navigation to '/species/<new-species-id>'. I don't think this is the best way to do this, but without it it rendered the wrong view approx 50% of the time when submitting a valid species entry. These entries are inserted to database correctly anyway, but a view for a new, empty species was rendered. So I guess the code tried to call navigate(`/species/${species_id}`) before species_id was defined and did not complete the navigation and returned to '/species/new'.

Another thing is that if the backend raises validation errors, atm it does not return the errors in the response.. Only the 400 code is returned. I don't know how to fix this