### PR TITLE
Make time unit editing more intuitive

### DIFF
--- a/frontend/src/components/DetailView/common/editingComponents.tsx
+++ b/frontend/src/components/DetailView/common/editingComponents.tsx
@@ -322,7 +322,6 @@ export const TimeBoundSelection = <T extends object, ParentType extends object>(
         </Modal>
       </Box>
     )
-
   const editingComponent = (
     <TextField
       variant="outlined"

--- a/frontend/src/components/DetailView/common/editingComponents.tsx
+++ b/frontend/src/components/DetailView/common/editingComponents.tsx
@@ -322,6 +322,7 @@ export const TimeBoundSelection = <T extends object, ParentType extends object>(
         </Modal>
       </Box>
     )
+
   const editingComponent = (
     <TextField
       variant="outlined"

--- a/frontend/src/components/DetailView/common/tabLayoutHelpers.tsx
+++ b/frontend/src/components/DetailView/common/tabLayoutHelpers.tsx
@@ -41,13 +41,15 @@ export const ArrayToTable = ({ array, half }: { array: Array<Array<ReactNode>>; 
 export const ArrayFrame = ({
   array,
   title,
+  highlighted,
   half,
 }: {
   array: Array<Array<ReactNode>>
   title: string
+  highlighted?: boolean
   half?: boolean
 }) => (
-  <Grouped title={title}>
+  <Grouped title={title} highlighted={highlighted}>
     <ArrayToTable half={half} array={array} />
   </Grouped>
 )
@@ -71,10 +73,12 @@ export const HalfFrames = ({ children }: { children: [ReactNode, ReactNode] }) =
 
 export const Grouped = ({
   title,
+  highlighted,
   children,
   style,
 }: {
   title?: string
+  highlighted?: boolean
   children: ReactNode
   style?: React.CSSProperties
 }) => {
@@ -83,13 +87,16 @@ export const Grouped = ({
     paddingBottom: '15px',
     backgroundColor: 'white',
     margin: '0em',
+    borderColor: highlighted ? 'orange' : '',
+    borderRadius: highlighted ? 4 : '',
+    borderStyle: highlighted ? 'none none none solid' : '',
   }
 
   return (
     <Card style={styles}>
       {title && (
         <>
-          <Typography sx={{ fontSize: 16 }} color="text.secondary" gutterBottom>
+          <Typography sx={{ fontSize: 16 }} color={'text.secondary'} gutterBottom>
             {title}
           </Typography>
           <Divider />

--- a/frontend/src/components/DetailView/common/tabLayoutHelpers.tsx
+++ b/frontend/src/components/DetailView/common/tabLayoutHelpers.tsx
@@ -96,7 +96,7 @@ export const Grouped = ({
     <Card style={styles}>
       {title && (
         <>
-          <Typography sx={{ fontSize: 16 }} color={'text.secondary'} gutterBottom>
+          <Typography sx={{ fontSize: 16 }} color="text.secondary" gutterBottom>
             {title}
           </Typography>
           <Divider />

--- a/frontend/src/components/TimeBound/TimeBoundTable.tsx
+++ b/frontend/src/components/TimeBound/TimeBoundTable.tsx
@@ -4,7 +4,13 @@ import { useGetAllTimeBoundsQuery } from '../../redux/timeBoundReducer'
 import { TimeBound } from '@/backendTypes'
 import { TableView } from '../TableView/TableView'
 
-export const TimeBoundTable = ({ selectorFn }: { selectorFn?: (newTimeBound: TimeBound) => void }) => {
+export const TimeBoundTable = ({
+  selectorFn,
+  showBid = false,
+}: {
+  selectorFn?: (newTimeBound: TimeBound) => void
+  showBid?: boolean
+}) => {
   const time_boundQuery = useGetAllTimeBoundsQuery()
   const columns = useMemo<MRT_ColumnDef<TimeBound>[]>(
     () => [
@@ -31,7 +37,7 @@ export const TimeBoundTable = ({ selectorFn }: { selectorFn?: (newTimeBound: Tim
   )
 
   const visibleColumns = {
-    bid: false,
+    bid: showBid,
   }
 
   return (

--- a/frontend/src/components/TimeUnit/Tabs/TimeUnitTab.tsx
+++ b/frontend/src/components/TimeUnit/Tabs/TimeUnitTab.tsx
@@ -7,7 +7,7 @@ import { SequenceTable } from '@/components/Sequence/SequenceTable'
 import { TimeBoundTable } from '@/components/TimeBound/TimeBoundTable'
 
 export const TimeUnitTab = () => {
-  const { textField, dropdown, data, mode } = useDetailContext<TimeUnitDetailsType>()
+  const { textField, dropdown, data, editData, mode } = useDetailContext<TimeUnitDetailsType>()
 
   const rankOptions = [
     'Age',
@@ -41,38 +41,38 @@ export const TimeUnitTab = () => {
   const low_bound = mode.new
     ? []
     : [
-        ['Id', data.low_bound?.bid],
-        ['Name', data.low_bound?.b_name],
-        ['Age', data.low_bound?.age],
-        ['Comment', data.low_bound?.b_comment],
+        ['Id', editData.low_bound!.bid],
+        ['Name', editData.low_bound!.b_name],
+        ['Age', editData.low_bound!.age],
+        ['Comment', editData.low_bound!.b_comment],
       ]
 
   const up_bound = mode.new
     ? []
     : [
-        ['Id', data.up_bound?.bid],
-        ['Name', data.up_bound?.b_name],
-        ['Age', data.up_bound?.age],
-        ['Comment', data.up_bound?.b_comment],
+        ['Id', editData.up_bound!.bid],
+        ['Name', editData.up_bound!.b_name],
+        ['Age', editData.up_bound!.age],
+        ['Comment', editData.up_bound!.b_comment],
       ]
 
   const time_bound_edit = [
     [
-      'New Upper Bound',
+      'New Upper Bound Id',
       <TimeBoundSelection<TimeBoundDetailsType, TimeUnitDetailsType>
         key="up_bnd"
         sourceField="bid"
         targetField="up_bnd"
-        selectorTable={<TimeBoundTable />}
+        selectorTable={<TimeBoundTable showBid />}
       />,
     ],
     [
-      'New Lower Bound',
+      'New Lower Bound Id',
       <TimeBoundSelection<TimeBoundDetailsType, TimeUnitDetailsType>
         key="low_bnd"
         sourceField="bid"
         targetField="low_bnd"
-        selectorTable={<TimeBoundTable />}
+        selectorTable={<TimeBoundTable showBid />}
       />,
     ],
   ]
@@ -82,8 +82,16 @@ export const TimeUnitTab = () => {
       <ArrayFrame array={timeUnit} title="Time Unit" />
       {!mode.new && (
         <>
-          <ArrayFrame array={low_bound} title="Lower bound" />
-          <ArrayFrame array={up_bound} title="Upper bound" />
+          <ArrayFrame
+            array={low_bound}
+            title={editData.low_bound!.bid === data.low_bound?.bid ? 'Lower bound' : 'Lower Bound (edited)'}
+            highlighted={editData.low_bound!.bid !== data.low_bound?.bid ? true : false}
+          />
+          <ArrayFrame
+            array={up_bound}
+            title={editData.up_bound!.bid === data.up_bound?.bid ? 'Upper bound' : 'Upper Bound (edited)'}
+            highlighted={editData.up_bound!.bid !== data.up_bound?.bid ? true : false}
+          />
         </>
       )}
       {!mode.read && <ArrayFrame array={time_bound_edit} title="Edit bounds" />}


### PR DESCRIPTION
When editing time unit, added a small border to time bound that has been changed so it's easier for the user to see. Also renamed "New Upper Bound" to "New Upper Bound Id" (same for lower bound), and the TableView that opens when the user is selecting a new time bound now shows ids by default.