### PR TITLE
radio selector now adds its defaultValue to editData

### DIFF
--- a/frontend/src/components/DetailView/common/editingComponents.tsx
+++ b/frontend/src/components/DetailView/common/editingComponents.tsx
@@ -138,7 +138,7 @@ export const RadioSelector = <T extends object>({
     defaultValue = getValue(options[0])
   }
   if (editData[field] === null) {
-    setEditData({ ...editData, [field]: getValue(options[0]) })
+    setEditData({ ...editData, [field]: defaultValue })
   }
   const editingComponent = (
     <FormControl>


### PR DESCRIPTION
Changed this because otherwise giving the RadioSelector a default value would not update the data