### PR TITLE
Calculate and insert max/min age from time unit + fraction into Age field

### DIFF
--- a/frontend/src/components/DetailView/common/editingComponents.tsx
+++ b/frontend/src/components/DetailView/common/editingComponents.tsx
@@ -229,17 +229,29 @@ export const FieldWithTableSelection = <T extends object, ParentType extends obj
   sourceField,
   selectorTable,
   disabled,
+  secondaryTargetField,
+  secondarySourceField,
 }: {
   targetField: keyof ParentType
   sourceField: keyof T
   selectorTable: ReactElement
   disabled?: boolean
+  secondaryTargetField?: keyof ParentType
+  secondarySourceField?: keyof T
 }) => {
   const { editData, setEditData, validator } = useDetailContext<ParentType>()
   const { error } = validator(editData, targetField as keyof EditDataType<ParentType>)
   const [open, setOpen] = useState(false)
   const selectorFn = (selected: T) => {
-    setEditData({ ...editData, [targetField]: selected[sourceField] })
+    if (secondaryTargetField && secondarySourceField) {
+      setEditData({
+        ...editData,
+        [targetField]: selected[sourceField],
+        [secondaryTargetField]: selected[secondarySourceField],
+      })
+    } else {
+      setEditData({ ...editData, [targetField]: selected[sourceField] })
+    }
     setOpen(false)
   }
 

--- a/frontend/src/components/Locality/Tabs/AgeTab.tsx
+++ b/frontend/src/components/Locality/Tabs/AgeTab.tsx
@@ -63,6 +63,8 @@ export const AgeTab = () => {
         targetField="bfa_min"
         selectorTable={<TimeUnitTable />}
         disabled={editData.date_meth === 'absolute'}
+        secondarySourceField="up_bound"
+        secondaryTargetField="min_age"
       />,
       dropdown('frac_min', fracOptions, 'Minimum fraction', editData.date_meth === 'absolute'),
     ],
@@ -76,6 +78,8 @@ export const AgeTab = () => {
         targetField="bfa_max"
         selectorTable={<TimeUnitTable />}
         disabled={editData.date_meth === 'absolute'}
+        secondarySourceField="low_bound"
+        secondaryTargetField="max_age"
       />,
       dropdown('frac_max', fracOptions, 'Maximum fraction', editData.date_meth === 'absolute'),
     ],


### PR DESCRIPTION
Insertion of max/min age implemented, need to include fraction calculation. Also need to merge making the age field read-only when time unit dating method is selected.