### PR TITLE
add initial functionality for timeunit cascades

### DIFF
--- a/backend/src/api-tests/timeUnit/update.test.ts
+++ b/backend/src/api-tests/timeUnit/update.test.ts
@@ -92,7 +92,7 @@ describe('Time unit updating works', () => {
 
   it('Updating with duplicate data should succeed', async () => {
     const result = await send('time-unit', 'PUT', {
-      timeUnit: editedTimeUnit,
+      timeUnit: { tu_name: 'baheantest', ...newTimeUnitBasis },
     })
     expect(result.status).toEqual(200)
   })

--- a/backend/src/api-tests/timeUnit/update.test.ts
+++ b/backend/src/api-tests/timeUnit/update.test.ts
@@ -19,7 +19,7 @@ describe('Time unit updating works', () => {
     await login()
     // create the existing time unit that is edited
     await send<{ tu_name: string }>('time-unit', 'PUT', {
-      timeUnit: { tu_name: "baheantest", ...newTimeUnitBasis },
+      timeUnit: { tu_name: 'baheantest', ...newTimeUnitBasis },
     })
   })
   afterAll(async () => {
@@ -90,7 +90,7 @@ describe('Time unit updating works', () => {
     testLogRows(logRows, expectedLogRows, 2)
   })
 
-  it("Updating with duplicate data should succeed", async () => {
+  it('Updating with duplicate data should succeed', async () => {
     const result = await send('time-unit', 'PUT', {
       timeUnit: editedTimeUnit,
     })

--- a/backend/src/api-tests/timeUnit/update.test.ts
+++ b/backend/src/api-tests/timeUnit/update.test.ts
@@ -10,12 +10,16 @@ const existingTimeUnit = { ...newTimeUnitBasis, tu_name: 'baheantest' }
 describe('Time unit updating works', () => {
   beforeAll(async () => {
     await resetDatabase()
+    await login()
+    await send<{ tu_name: string }>('time-unit', 'PUT', {
+      timeUnit: { ...newTimeUnitBasis },
+    })
   }, resetDatabaseTimeout)
   beforeEach(async () => {
     await login()
     // create the existing time unit that is edited
     await send<{ tu_name: string }>('time-unit', 'PUT', {
-      timeUnit: { ...newTimeUnitBasis },
+      timeUnit: { tu_name: "baheantest", ...newTimeUnitBasis },
     })
   })
   afterAll(async () => {
@@ -84,5 +88,12 @@ describe('Time unit updating works', () => {
       },
     ]
     testLogRows(logRows, expectedLogRows, 2)
+  })
+
+  it("Updating with duplicate data should succeed", async () => {
+    const result = await send('time-unit', 'PUT', {
+      timeUnit: editedTimeUnit,
+    })
+    expect(result.status).toEqual(200)
   })
 })

--- a/backend/src/routes/timeUnit.ts
+++ b/backend/src/routes/timeUnit.ts
@@ -46,7 +46,10 @@ router.put(
     if (validationErrors.length > 0) {
       return res.status(403).send(validationErrors)
     }
-    const tu_name = await writeTimeUnit(editedTimeUnit, comment, references, req.user!.initials)
+    const { tu_name, errorObject } = await writeTimeUnit(editedTimeUnit, comment, references, req.user!.initials)
+    if (errorObject !== undefined) {
+      return res.status(403).send({ errorObject })
+    }
     return res.status(200).send({ tu_name })
   }
 )

--- a/backend/src/services/write/locality.ts
+++ b/backend/src/services/write/locality.ts
@@ -111,3 +111,21 @@ export const deleteLocality = async (lid: number, user: User) => {
     throw e
   }
 }
+
+export const writeLocalityCascade = async (
+  locality: EditDataType<LocalityDetailsType>,
+  comment: string | undefined,
+  references: Reference[] | undefined,
+  authorizer: string
+) => {
+  const writeHandler = getLocalityWriteHandler('update')
+  try {
+    await writeHandler.start()
+    await writeHandler.updateObject('now_loc', locality, ['lid'])
+    writeHandler.idValue = locality.lid
+    await writeHandler.logUpdatesAndComplete(authorizer, comment ?? '', references ?? [])
+  } catch (e) {
+    await writeHandler.end()
+    throw e
+  }
+}

--- a/backend/src/services/write/species.ts
+++ b/backend/src/services/write/species.ts
@@ -38,7 +38,6 @@ export const writeSpecies = async (
     await writeHandler.applyListChanges('now_ls', species.now_ls, ['lid', 'species_id'])
     await writeHandler.applyListChanges('com_taxa_synonym', species.com_taxa_synonym, ['synonym_id', 'species_id'])
     await writeHandler.logUpdatesAndComplete(authorizer, comment ?? '', references ?? [])
-    await writeHandler.commit()
 
     return species.species_id
   } catch (e) {

--- a/backend/src/services/write/timeUnit.ts
+++ b/backend/src/services/write/timeUnit.ts
@@ -1,9 +1,17 @@
-import { EditDataType, Reference, TimeUnitDetailsType, User } from '../../../../frontend/src/backendTypes'
+import {
+  EditDataType,
+  Reference,
+  TimeUnitDetailsType,
+  LocalityDetailsType,
+  User,
+} from '../../../../frontend/src/backendTypes'
 import { NOW_DB_NAME } from '../../utils/config'
 import { WriteHandler } from './writeOperations/writeHandler'
 import { getFieldsOfTables } from '../../utils/db'
 import { ActionType } from './writeOperations/types'
 import { getTimeUnitDetails } from '../timeUnit'
+import { checkTimeUnitCascade } from '../../utils/cascadeHandler'
+import { writeLocalityCascade } from './locality'
 
 const getTimeUnitWriteHandler = (type: ActionType) => {
   return new WriteHandler({
@@ -32,6 +40,25 @@ export const writeTimeUnit = async (
 
     if (timeUnit.tu_name) {
       await writeHandler.updateObject('now_time_unit', timeUnit, ['tu_name'])
+      const { cascadeErrors, calculatorErrors, localitiesToUpdate } = await checkTimeUnitCascade(timeUnit)
+
+      if (calculatorErrors.length > 0 || cascadeErrors.length > 0) {
+        const calculatorErrorsString =
+          calculatorErrors.length > 0 ? `Check fractions of following localities: ${calculatorErrors.join(', ')}` : ''
+        const cascadeErrorsString =
+          cascadeErrors.length > 0 ? `Following localities would become contradicting: ${cascadeErrors.join(', ')}` : ''
+        const ErrorObject = {
+          name: 'cascade',
+          calculatorErrors: calculatorErrorsString,
+          cascadeErrors: cascadeErrorsString,
+        }
+        await writeHandler.end()
+        return { tu_name: timeUnit.tu_name, errorObject: ErrorObject }
+      } else if (localitiesToUpdate.length > 0) {
+        for (const locality of localitiesToUpdate) {
+          await writeLocalityCascade(locality as EditDataType<LocalityDetailsType>, comment, references, authorizer)
+        }
+      }
     } else {
       timeUnit.tu_name = createTimeUnitId(timeUnit.tu_display_name!)
       await writeHandler.createObject('now_time_unit', timeUnit, ['tu_name'])
@@ -40,7 +67,7 @@ export const writeTimeUnit = async (
     await writeHandler.logUpdatesAndComplete(authorizer, comment ?? '', references ?? [])
     await writeHandler.commit()
 
-    return timeUnit.tu_name
+    return { tu_name: timeUnit.tu_name, errorObject: undefined }
   } catch (e) {
     await writeHandler.end()
     throw e

--- a/backend/src/services/write/timeUnit.ts
+++ b/backend/src/services/write/timeUnit.ts
@@ -65,7 +65,6 @@ export const writeTimeUnit = async (
     }
     writeHandler.idValue = createdId
     await writeHandler.logUpdatesAndComplete(authorizer, comment ?? '', references ?? [])
-    await writeHandler.commit()
 
     return { tu_name: timeUnit.tu_name, errorObject: undefined }
   } catch (e) {

--- a/backend/src/services/write/writeOperations/writeHandler.ts
+++ b/backend/src/services/write/writeOperations/writeHandler.ts
@@ -120,9 +120,9 @@ export class WriteHandler extends DatabaseHandler {
   async logUpdatesAndComplete(authorizer: string, comment?: string, references?: Reference[]) {
     if (this.writeList.flatMap(writeItem => writeItem.items).length === 0) {
       logger.info(`No changes detected, skipping logging.`)
-      return
+    } else {
+      await logAllUpdates(this, this.writeList, this.table, this.idValue!, authorizer, this.type, comment, references)
     }
-    await logAllUpdates(this, this.writeList, this.table, this.idValue!, authorizer, this.type, comment, references)
     await this.commit()
     await this.end()
   }

--- a/backend/src/utils/cascadeHandler.ts
+++ b/backend/src/utils/cascadeHandler.ts
@@ -1,0 +1,51 @@
+import { EditDataType, TimeUnitDetailsType } from '../../../frontend/src/backendTypes'
+import { nowDb } from './db'
+import { calculateLocalityMaxAge, calculateLocalityMinAge } from './ageCalculator'
+
+export const checkTimeUnitCascade = async (timeUnit: EditDataType<TimeUnitDetailsType>) => {
+  const localities = await nowDb.now_loc.findMany({
+    where: {
+      OR: [{ bfa_max: timeUnit.tu_name }, { bfa_min: timeUnit.tu_name }],
+    },
+  })
+  const cascadeErrors: string[] = []
+  const calculatorErrors: string[] = []
+  const localitiesToUpdate = []
+  for (const locality of localities) {
+    let maxAgeAfterUpdate = locality.max_age
+    let minAgeAfterUpdate = locality.min_age
+    if (locality.bfa_max === timeUnit.tu_name) {
+      try {
+        maxAgeAfterUpdate = calculateLocalityMaxAge(
+          timeUnit.up_bound?.age as number,
+          timeUnit.low_bound?.age as number,
+          locality.frac_max
+        )
+      } catch (e) {
+        calculatorErrors.push(locality.loc_name)
+      }
+    }
+    if (locality.bfa_min === timeUnit.tu_name) {
+      try {
+        minAgeAfterUpdate = calculateLocalityMinAge(
+          timeUnit.up_bound?.age as number,
+          timeUnit.low_bound?.age as number,
+          locality.frac_max
+        )
+      } catch (e) {
+        calculatorErrors.push(locality.loc_name)
+      }
+    }
+    if (minAgeAfterUpdate < maxAgeAfterUpdate) {
+      const updatedLocality = {
+        ...locality,
+        min_age: minAgeAfterUpdate,
+        max_age: maxAgeAfterUpdate,
+      }
+      localitiesToUpdate.push(updatedLocality)
+    } else {
+      cascadeErrors.push(locality.loc_name)
+    }
+  }
+  return { cascadeErrors, calculatorErrors, localitiesToUpdate }
+}

--- a/backend/src/utils/db.ts
+++ b/backend/src/utils/db.ts
@@ -74,6 +74,7 @@ export const testDbConnection = async () => {
 // TODO this is very slow to execute, around 4500ms each time. Not good...
 export const resetTestDb = async () => {
   if (RUNNING_ENV !== 'dev') throw new Error(`Trying to reset test database with RUNNING_ENV ${RUNNING_ENV}`)
+  logger.info("Resetting test database...")
 
   const createTestConnection = (dbName: string) => {
     return mariadb.createConnection({
@@ -83,6 +84,7 @@ export const resetTestDb = async () => {
       checkDuplicate: false,
       multipleStatements: true,
       database: dbName,
+      trace: true,
     })
   }
 

--- a/backend/src/utils/db.ts
+++ b/backend/src/utils/db.ts
@@ -74,7 +74,7 @@ export const testDbConnection = async () => {
 // TODO this is very slow to execute, around 4500ms each time. Not good...
 export const resetTestDb = async () => {
   if (RUNNING_ENV !== 'dev') throw new Error(`Trying to reset test database with RUNNING_ENV ${RUNNING_ENV}`)
-  logger.info("Resetting test database...")
+  logger.info('Resetting test database...')
 
   const createTestConnection = (dbName: string) => {
     return mariadb.createConnection({

--- a/cypress/e2e/timeUnit.cy.js
+++ b/cypress/e2e/timeUnit.cy.js
@@ -1,10 +1,11 @@
+before('Reset database', () => {
+    cy.request(Cypress.env("databaseResetUrl"));
+});
+
 describe("Editing time unit", () => {
     beforeEach('Login as admin', () => {
         cy.login('testSu')
     })
-    beforeEach('Reset database', () => {
-        cy.request(Cypress.env("databaseResetUrl"));
-    });
     it("User editing time unit with correct values succeeds", () => {
         cy.visit(`/time-unit/bahean?tab=0`)
         cy.contains('Bahean')


### PR DESCRIPTION
Cascading effects of time units are now checked and edits don't go through if contradicting localities would emerge.

These are only checked, if time unit itself is valid and cascading errors are separated from validation errors.

Notifying errors correctly will be in another task