### PR TITLE
Timebound cascade effects

### DIFF
--- a/backend/src/api-tests/timeBound/update.test.ts
+++ b/backend/src/api-tests/timeBound/update.test.ts
@@ -59,6 +59,13 @@ describe('Time bound updating', () => {
     expect(body.b_name).toEqual(existingTimeBound.b_name)
     expect(body.age).toEqual(existingTimeBound.age)
   })
+  it('Update request that would create contradictory timeunit or locality fails', async () => {
+    const  { body: resultBody, status: status } = await send<{ bid: number }>('time-bound', 'PUT', {
+      timeBound: { ...existingTimeBound, age: 2.5 },
+    })
+    expect(status).toEqual(403)
+    expect(resultBody).toEqual({"calculatorErrors": "", "cascadeErrors": "Following time units or localities would become contradicting: olduvai", "name": "cascade"})
+  })
   it('Update logs are correct', async () => {
     const { body: resultBody } = await send<{ bid: number }>('time-bound', 'PUT', {
       timeBound: editedTimeBound,

--- a/backend/src/api-tests/timeBound/update.test.ts
+++ b/backend/src/api-tests/timeBound/update.test.ts
@@ -60,11 +60,15 @@ describe('Time bound updating', () => {
     expect(body.age).toEqual(existingTimeBound.age)
   })
   it('Update request that would create contradictory timeunit or locality fails', async () => {
-    const  { body: resultBody, status: status } = await send<{ bid: number }>('time-bound', 'PUT', {
+    const { body: resultBody, status: status } = await send<{ bid: number }>('time-bound', 'PUT', {
       timeBound: { ...existingTimeBound, age: 2.5 },
     })
     expect(status).toEqual(403)
-    expect(resultBody).toEqual({"calculatorErrors": "", "cascadeErrors": "Following time units or localities would become contradicting: olduvai", "name": "cascade"})
+    expect(resultBody).toEqual({
+      calculatorErrors: '',
+      cascadeErrors: 'Following time units or localities would become contradicting: olduvai',
+      name: 'cascade',
+    })
   })
   it('Update logs are correct', async () => {
     const { body: resultBody } = await send<{ bid: number }>('time-bound', 'PUT', {

--- a/backend/src/routes/timeBound.ts
+++ b/backend/src/routes/timeBound.ts
@@ -40,7 +40,10 @@ router.put(
     if (validationErrors.length > 0) {
       return res.status(403).send(validationErrors)
     }
-    const result = await writeTimeBound(editedTimeBound, comment, references, req.user!.initials)
+    const { result, errorObject } = await writeTimeBound(editedTimeBound, comment, references, req.user!.initials)
+    if (errorObject) {
+      return res.status(403).send(errorObject)
+    }
     return res.status(200).send({ bid: result })
   }
 )

--- a/backend/src/routes/timeUnit.ts
+++ b/backend/src/routes/timeUnit.ts
@@ -61,7 +61,7 @@ router.put(
       return res.status(403).send(validationErrors)
     }
     const { tu_name, errorObject } = await writeTimeUnit(editedTimeUnit, comment, references, req.user!.initials)
-    if (errorObject !== undefined) {
+    if (errorObject) {
       return res.status(403).send(errorObject)
     }
     return res.status(200).send({ tu_name })

--- a/backend/src/services/write/timeBound.ts
+++ b/backend/src/services/write/timeBound.ts
@@ -4,6 +4,7 @@ import { WriteHandler } from './writeOperations/writeHandler'
 import { getFieldsOfTables } from '../../utils/db'
 import { ActionType } from './writeOperations/types'
 import { getTimeBoundDetails } from '../timeBound'
+import { checkTimeBoundCascade } from '../../utils/cascadeHandler'
 
 const getTimeBoundWriteHandler = (type: ActionType) => {
   return new WriteHandler({
@@ -27,6 +28,7 @@ export const writeTimeBound = async (
   try {
     await writeHandler.start()
     const result = await writeHandler.upsertObject('now_tu_bound', timeBound, ['bid'])
+    const { cascadeErrors, calculatorErrors, localitiesToUpdate } = await checkTimeBoundCascade(timeBound)
     writeHandler.idValue = result ? (result.bid as number) : (timeBound.bid as number)
     await writeHandler.logUpdatesAndComplete(authorizer, comment ?? '', references ?? [])
     return { result: writeHandler.idValue, errorObject: undefined }

--- a/backend/src/services/write/timeBound.ts
+++ b/backend/src/services/write/timeBound.ts
@@ -1,10 +1,19 @@
-import { EditDataType, Reference, TimeBoundDetailsType, User } from '../../../../frontend/src/backendTypes'
+import {
+  EditDataType,
+  Reference,
+  TimeBoundDetailsType,
+  LocalityDetailsType,
+  TimeUnitDetailsType,
+  User,
+} from '../../../../frontend/src/backendTypes'
 import { NOW_DB_NAME } from '../../utils/config'
 import { WriteHandler } from './writeOperations/writeHandler'
 import { getFieldsOfTables } from '../../utils/db'
 import { ActionType } from './writeOperations/types'
 import { getTimeBoundDetails } from '../timeBound'
 import { checkTimeBoundCascade } from '../../utils/cascadeHandler'
+import { writeLocalityCascade } from './locality'
+import { logTimeUnit } from './timeUnit'
 
 const getTimeBoundWriteHandler = (type: ActionType) => {
   return new WriteHandler({
@@ -28,10 +37,18 @@ export const writeTimeBound = async (
   try {
     await writeHandler.start()
     const result = await writeHandler.upsertObject('now_tu_bound', timeBound, ['bid'])
-    const { cascadeErrors, calculatorErrors, localitiesToUpdate, timeUnitsToUpdate } = await checkTimeBoundCascade(timeBound)
+    writeHandler.idValue = result ? (result.bid as number) : (timeBound.bid as number)
+
+    const { cascadeErrors, calculatorErrors, localitiesToUpdate, timeUnitsToUpdate } =
+      await checkTimeBoundCascade(timeBound)
+
     if (calculatorErrors.length > 0 || cascadeErrors.length > 0) {
-      const calculatorErrorsString = calculatorErrors.length > 0 ? `Check fractions of following localities: ${calculatorErrors.join(', ')}` : ''
-      const cascadeErrorsString = cascadeErrors.length > 0 ? `Following localities would become contradicting: ${cascadeErrors.join(', ')}` : ''
+      const calculatorErrorsString =
+        calculatorErrors.length > 0 ? `Check fractions of following localities: ${calculatorErrors.join(', ')}` : ''
+      const cascadeErrorsString =
+        cascadeErrors.length > 0
+          ? `Following time units or localities would become contradicting: ${cascadeErrors.join(', ')}`
+          : ''
       const errorObject = {
         name: 'cascade',
         calculatorErrors: calculatorErrorsString,
@@ -40,7 +57,18 @@ export const writeTimeBound = async (
       await writeHandler.end()
       return { result: writeHandler.idValue, errorObject }
     }
-    writeHandler.idValue = result ? (result.bid as number) : (timeBound.bid as number)
+    if (localitiesToUpdate.length > 0) {
+      for (const locality of localitiesToUpdate) {
+        await writeLocalityCascade(locality as EditDataType<LocalityDetailsType>, comment, references, authorizer)
+      }
+    }
+
+    if (timeUnitsToUpdate.length > 0) {
+      for (const timeUnit of timeUnitsToUpdate) {
+        logTimeUnit(timeUnit as unknown as EditDataType<TimeUnitDetailsType>, comment, references, authorizer)
+      }
+    }
+
     await writeHandler.logUpdatesAndComplete(authorizer, comment ?? '', references ?? [])
     return { result: writeHandler.idValue, errorObject: undefined }
   } catch (e) {

--- a/backend/src/services/write/timeBound.ts
+++ b/backend/src/services/write/timeBound.ts
@@ -29,7 +29,7 @@ export const writeTimeBound = async (
     const result = await writeHandler.upsertObject('now_tu_bound', timeBound, ['bid'])
     writeHandler.idValue = result ? (result.bid as number) : (timeBound.bid as number)
     await writeHandler.logUpdatesAndComplete(authorizer, comment ?? '', references ?? [])
-    return writeHandler.idValue
+    return { result: writeHandler.idValue, errorObject: undefined }
   } catch (e) {
     await writeHandler.end()
     throw e

--- a/backend/src/services/write/timeUnit.ts
+++ b/backend/src/services/write/timeUnit.ts
@@ -86,3 +86,15 @@ export const deleteTimeUnit = async (id: string, user: User) => {
     throw e
   }
 }
+
+export const logTimeUnit = (
+  timeUnit: EditDataType<TimeUnitDetailsType>,
+  comment: string | undefined,
+  references: Reference[] | undefined,
+  authorizer: string
+) => {
+  if (timeUnit && comment && references && authorizer) {
+    // TODO
+  }
+  // TODO
+}

--- a/backend/src/utils/cascadeHandler.ts
+++ b/backend/src/utils/cascadeHandler.ts
@@ -67,6 +67,7 @@ type EditedUnit = {
 }
 
 type Locality = {
+  lid: number
   loc_name: string
   max_age: number
   min_age: number
@@ -123,6 +124,7 @@ export const checkTimeBoundCascade = async (timeBound: EditDataType<TimeBoundDet
   for (const timeUnit of timeUnitsToUpdate) {
     const localities = (await nowDb.now_loc.findMany({
       select: {
+        lid: true,
         loc_name: true,
         max_age: true,
         min_age: true,

--- a/backend/src/utils/cascadeHandler.ts
+++ b/backend/src/utils/cascadeHandler.ts
@@ -56,14 +56,20 @@ type Bounds = {
 }
 
 type Unit = {
+  tu_name: string
   up_bnd: number
   low_bnd: number
 }
 
 
 export const checkTimeBoundCascade = async (timeBound: EditDataType<TimeBoundDetailsType>) => {
+  const cascadeErrors: string[] = []
+  const calculatorErrors: string[] = []
+  const localitiesToCheck = []
+  const timeUnitsToUpdate = []
   const timeUnits = await nowDb.now_time_unit.findMany({
     select: {
+      tu_name: true,
       up_bnd: true,
       low_bnd: true,
     },
@@ -82,28 +88,64 @@ export const checkTimeBoundCascade = async (timeBound: EditDataType<TimeBoundDet
       },
     })
     if (bounds.length === 2) {
-      console.log(checkAges(timeUnit, bounds as Bounds[], timeBound.age as number, timeBound.bid as number))
+      const editedBounds = calculateTimeUnitAges(timeUnit, bounds as Bounds[], timeBound.age as number, timeBound.bid as number);
+      if (editedBounds) {
+        if (editedBounds.lowBoundAge > editedBounds.upBoundAge) {
+          timeUnitsToUpdate.push(timeUnit)
+        } else {
+          cascadeErrors.push(timeUnit.tu_name)
+        }
+      } else {
+        calculatorErrors.push(timeUnit.tu_name)
+      }
     } else {
       console.log("Not enough bounds found for time unit. Bad")
     }
   }
-  return { cascadeErrors: [], calculatorErrors: [], timeUnitsToUpdate: [] }
+  for (const timeUnit of timeUnitsToUpdate) {
+    const localities = await nowDb.now_loc.findMany({
+      select: {
+        loc_name: true,
+        max_age: true,
+        min_age: true,
+        bfa_max: true,
+        bfa_min: true,
+        frac_max: true,
+      },
+      where: {
+        OR: [{ bfa_max: timeUnit.tu_name }, { bfa_min: timeUnit.tu_name }],
+      },
+    })
+    for (const locality of localities) {
+      localitiesToCheck.push(locality)
+    }
+  }
+  const { cascadeErrorsLocalities, calculatorErrorsLocalities, localitiesToUpdate } = await handleLocalityAndTimeUnitLists(localitiesToCheck, timeUnitsToUpdate)
+  console.log(localitiesToCheck)
+  return { cascadeErrors, calculatorErrors, localitiesToUpdate, timeUnitsToUpdate }
 }
 
-function checkAges(
+const calculateTimeUnitAges = (
   unit: Unit,
   list: Bounds[],
   editedAge: number,
   bid: number
-): boolean | undefined {
+) => {
   const upBoundEntry = list.find(item => item.bid === unit.up_bnd);
   const lowBoundEntry = list.find(item => item.bid === unit.low_bnd);
   if (upBoundEntry && lowBoundEntry) {
     const upBoundAge = unit.up_bnd === bid ? editedAge : upBoundEntry.age;
     const lowBoundAge = unit.low_bnd === bid ? editedAge : lowBoundEntry.age;
-    return upBoundAge < lowBoundAge;
+    return { upBoundAge, lowBoundAge };
   } else {
     console.error("One or both bounds not found in the list.");
     return undefined;
   }
+}
+
+const handleLocalityAndTimeUnitLists = (localities: any[], timeUnits: any[]) => {
+  const cascadeErrorsLocalities: string[] = []
+  const calculatorErrorsLocalities: string[] = []
+  const localitiesToUpdate: any[] = []
+  return { cascadeErrorsLocalities, calculatorErrorsLocalities, localitiesToUpdate }
 }

--- a/backend/src/utils/cascadeHandler.ts
+++ b/backend/src/utils/cascadeHandler.ts
@@ -1,4 +1,4 @@
-import { EditDataType, TimeUnitDetailsType } from '../../../frontend/src/backendTypes'
+import { EditDataType, TimeUnitDetailsType, TimeBoundDetailsType } from '../../../frontend/src/backendTypes'
 import { nowDb } from './db'
 import { calculateLocalityMaxAge, calculateLocalityMinAge } from './ageCalculator'
 
@@ -48,4 +48,62 @@ export const checkTimeUnitCascade = async (timeUnit: EditDataType<TimeUnitDetail
     }
   }
   return { cascadeErrors, calculatorErrors, localitiesToUpdate }
+}
+
+type Bounds = {
+  bid: number
+  age: number
+}
+
+type Unit = {
+  up_bnd: number
+  low_bnd: number
+}
+
+
+export const checkTimeBoundCascade = async (timeBound: EditDataType<TimeBoundDetailsType>) => {
+  const timeUnits = await nowDb.now_time_unit.findMany({
+    select: {
+      up_bnd: true,
+      low_bnd: true,
+    },
+    where: {
+      OR: [{ up_bnd: timeBound.bid }, { low_bnd: timeBound.bid }],
+    },
+  })
+  for (const timeUnit of timeUnits) {
+    const bounds = await nowDb.now_tu_bound.findMany({
+      select: {
+        bid: true,
+        age: true,
+      },
+      where: {
+        OR: [{ bid: timeUnit.up_bnd }, { bid: timeUnit.low_bnd }],
+      },
+    })
+    if (bounds.length === 2) {
+      console.log(checkAges(timeUnit, bounds as Bounds[], timeBound.age as number, timeBound.bid as number))
+    } else {
+      console.log("Not enough bounds found for time unit. Bad")
+    }
+  }
+  return { cascadeErrors: [], calculatorErrors: [], timeUnitsToUpdate: [] }
+}
+
+function checkAges(
+  unit: Unit,
+  list: Bounds[],
+  editedAge: number,
+  bid: number
+): boolean | undefined {
+  const upBoundEntry = list.find(item => item.bid === unit.up_bnd);
+  const lowBoundEntry = list.find(item => item.bid === unit.low_bnd);
+  if (upBoundEntry && lowBoundEntry) {
+    const upBoundAge = unit.up_bnd === bid ? editedAge : upBoundEntry.age;
+    const lowBoundAge = unit.low_bnd === bid ? editedAge : lowBoundEntry.age;
+    return upBoundAge < lowBoundAge;
+  } else {
+    console.error("One or both bounds not found in the list.");
+    return undefined;
+  }
 }

--- a/cypress/e2e/timeBound.cy.js
+++ b/cypress/e2e/timeBound.cy.js
@@ -10,11 +10,11 @@ describe('Editing time bound', () => {
     cy.visit(`/time-bound/11?tab=0`)
     cy.contains('C2N-y')
     cy.get('[id=edit-button]').click()
-    cy.get('[id=age-textfield]').first().type('{backspace}{backspace}{backspace}{backspace}{backspace}2.5')
+    cy.get('[id=age-textfield]').first().type('{backspace}{backspace}{backspace}{backspace}{backspace}1.5')
     cy.contains('This field is required').should('not.exist')
     cy.get('[id=write-button]').click()
     cy.get('[id=write-button]').click()
-    cy.contains('2.5')
+    cy.contains('1.5')
   })
 
   it('User editing time bound with incorrect values is notified about it', () => {

--- a/frontend/src/components/TimeBound/TimeBoundDetails.tsx
+++ b/frontend/src/components/TimeBound/TimeBoundDetails.tsx
@@ -55,16 +55,16 @@ export const TimeBoundDetails = () => {
       setTimeout(() => navigate(`/time-bound/${bid}`), 15)
       notify('Edited item successfully.')
     } catch (e) {
-    if (
-      e &&
-      typeof e === 'object' &&
-      'status' in e &&
-      e.status === 403 &&
-      'data' in e &&
-      e.data &&
-      typeof e.data === 'object'
-    ) {
-      if ('name' in e.data) {
+      if (
+        e &&
+        typeof e === 'object' &&
+        'status' in e &&
+        e.status === 403 &&
+        'data' in e &&
+        e.data &&
+        typeof e.data === 'object'
+      ) {
+        if ('name' in e.data) {
           if ('cascadeErrors' in e.data && e.data.cascadeErrors !== '') {
             notify(e.data.cascadeErrors as string, 'error')
           }
@@ -78,8 +78,8 @@ export const TimeBoundDetails = () => {
       } else {
         notify('Could not edit item. Uncaught error happened.', 'error')
       }
-    }}
-  
+    }
+  }
 
   const tabs: TabType[] = [
     {

--- a/frontend/src/components/TimeBound/TimeBoundDetails.tsx
+++ b/frontend/src/components/TimeBound/TimeBoundDetails.tsx
@@ -53,11 +53,33 @@ export const TimeBoundDetails = () => {
     try {
       const { bid } = await editTimeBoundRequest(editedTimeBound).unwrap()
       setTimeout(() => navigate(`/time-bound/${bid}`), 15)
+      notify('Edited item successfully.')
     } catch (e) {
-      const error = e as ValidationErrors
-      notify('Following validators failed: ' + error.data.map(e => e.name).join(', '), 'error')
-    }
-  }
+    if (
+      e &&
+      typeof e === 'object' &&
+      'status' in e &&
+      e.status === 403 &&
+      'data' in e &&
+      e.data &&
+      typeof e.data === 'object'
+    ) {
+      if ('name' in e.data) {
+          if ('cascadeErrors' in e.data && e.data.cascadeErrors !== '') {
+            notify(e.data.cascadeErrors as string, 'error')
+          }
+          if ('calculatorErrors' in e.data && e.data.calculatorErrors !== '') {
+            notify(e.data.calculatorErrors as string, 'error')
+          }
+        } else {
+          const error = e as ValidationErrors
+          notify('Following validators failed: ' + error.data.map(e => e.name).join(', '), 'error')
+        }
+      } else {
+        notify('Could not edit item. Uncaught error happened.', 'error')
+      }
+    }}
+  
 
   const tabs: TabType[] = [
     {


### PR DESCRIPTION
Editing timebounds checks if it would break time units or localities before making changes. If something would break, changes are cancelled and user is informed. If nothing would break, all entities are updated. Time units are not yet logged

Updated tests to manage the changes and added 1 api-test for breaking timeunit when editing time bound