### PR TITLE
added phpmyadmin to docker compose of dev environments

### DIFF
--- a/docker-compose.anon.yml
+++ b/docker-compose.anon.yml
@@ -49,5 +49,16 @@ services:
       timeout: 5s
       retries: 3
 
+  phpmyadmin:
+    restart: always
+    image: phpmyadmin:5.2.1
+    environment:
+      PMA_ARBITRARY: 1
+      PMA_HOST: db-anon
+      PMA_PORT: 3306
+    ports:
+      - "8080:80"
+      - "9090:443"
+
 volumes:
   nowdb-db-anon:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -34,6 +34,16 @@ services:
     ports:
       - 127.0.0.1:3306:3306
 
+  phpmyadmin:
+    restart: always
+    image: phpmyadmin:5.2.1
+    environment:
+      PMA_ARBITRARY: 1
+      PMA_HOST: db
+      PMA_PORT: 3306
+    ports:
+      - "8080:80"
+      - "9090:443"
+
 volumes:
   nowdb-db:
-


### PR DESCRIPTION
phpMyAdmin seemed like the better option as adminer has not been maintained for 2 years. There is a fork `adminerevo` but PMA feels like the more "stable" option at the moment.