### PR TITLE
add optional custom timeout value to notifications

### DIFF
--- a/frontend/src/components/TimeBound/TimeBoundDetails.tsx
+++ b/frontend/src/components/TimeBound/TimeBoundDetails.tsx
@@ -66,10 +66,10 @@ export const TimeBoundDetails = () => {
       ) {
         if ('name' in e.data) {
           if ('cascadeErrors' in e.data && e.data.cascadeErrors !== '') {
-            notify(e.data.cascadeErrors as string, 'error')
+            notify(e.data.cascadeErrors as string, 'error', null)
           }
           if ('calculatorErrors' in e.data && e.data.calculatorErrors !== '') {
-            notify(e.data.calculatorErrors as string, 'error')
+            notify(e.data.calculatorErrors as string, 'error', null)
           }
         } else {
           const error = e as ValidationErrors

--- a/frontend/src/components/TimeUnit/TimeUnitDetails.tsx
+++ b/frontend/src/components/TimeUnit/TimeUnitDetails.tsx
@@ -71,10 +71,10 @@ export const TimeUnitDetails = () => {
       ) {
         if ('name' in e.data) {
           if ('cascadeErrors' in e.data && e.data.cascadeErrors !== '') {
-            notify(e.data.cascadeErrors as string, 'error')
+            notify(e.data.cascadeErrors as string, 'error', null)
           }
           if ('calculatorErrors' in e.data && e.data.calculatorErrors !== '') {
-            notify(e.data.calculatorErrors as string, 'error')
+            notify(e.data.calculatorErrors as string, 'error', null)
           }
         } else {
           const error = e as ValidationErrors


### PR DESCRIPTION
also changed the cascadeError/calculateError messages to not close automatically.