### PR TITLE
Frontend editing functionality for regions

### DIFF
--- a/backend/src/services/write/region.ts
+++ b/backend/src/services/write/region.ts
@@ -66,7 +66,7 @@ export const writeRegion = async (region: EditDataType<RegionDetails>) => {
   }
 
   if (region.now_reg_coord_people) {
-    const coordinatorsToWrite = region.now_reg_coord_people
+    const coordinatorsToWrite = region.now_reg_coord_people.filter(coordinator => coordinator.rowState !== 'removed')
     await writeRegionCoordinators(regionId, coordinatorsToWrite)
   }
 

--- a/cypress/e2e/region.cy.js
+++ b/cypress/e2e/region.cy.js
@@ -1,0 +1,83 @@
+before('Reset database', () => {
+  cy.request(Cypress.env('databaseResetUrl'))
+})
+
+describe('Creating a region', () => {
+  beforeEach('Login as admin', () => {
+    cy.login('testSu')
+  })
+
+  it.skip('with valid data works', () => {
+    cy.visit('/region/new')
+    cy.get('[id=order_name-textfield]').type('testOrder')
+    cy.get('[id=family_name-textfield]').type('testFamily')
+    cy.get('[id=genus_name-textfield]').type('testGenus')
+    cy.get('[id=species_name-textfield]').type('testSpecies')
+    cy.get('[id=write-button]').should('not.be.disabled')
+    cy.get('[id=write-button]').click()
+    cy.get('[id=write-button]').should('be.disabled')
+    cy.contains('button', 'Add existing reference').click()
+    cy.get('button[data-cy^="detailview-button"]').first().click()
+    cy.contains('button', 'Close').click()
+    cy.get('[id=write-button]').should('not.be.disabled')
+    cy.get('[id=write-button]').click()
+    cy.contains('testOrder')
+  })
+
+  it.skip('with missing required fields does not work', () => {
+    cy.visit('/species/new')
+    cy.contains('This field is required')
+    cy.get('[id=write-button]').should('be.disabled')
+    cy.contains('4 Invalid fields')
+  })
+})
+
+describe('Editing a region', () => {
+  beforeEach('Login as admin', () => {
+    cy.login('testSu')
+  })
+
+  it('with valid data works', () => {
+    cy.visit(`/region/1?tab=0`)
+    cy.contains('region 4452477e')
+    cy.contains('prs')
+    cy.contains('France')
+    cy.get('[id=edit-button]').click()
+    cy.contains('Select Coordinator').click()
+    cy.get('[data-cy=detailview-button-AD]').click()
+    cy.contains('Close').click()
+    cy.contains('ads')
+    //cy.get('Add new Country').click()
+    cy.get('[id=write-button]').click()
+    cy.contains('prs')
+    cy.contains('ads')
+    cy.contains('France')
+    cy.contains('Spain')
+  })
+
+  it('without any regional coordinators or countries works', () => {
+    cy.visit(`/region/1?tab=0`)
+    cy.contains('region 4452477e')
+    cy.contains('prs')
+    cy.contains('ads')
+    cy.contains('France')
+    cy.contains('Spain')
+    cy.get('[id=edit-button]').click()
+    cy.get('[data-testid=RemoveCircleOutlineIcon]').first().click()
+    cy.get('[data-testid=RemoveCircleOutlineIcon]').first().click() // the two regional coordinators
+    cy.get('[id=write-button]').click()
+    cy.contains('region 4452477e')
+    cy.contains('prs').should('not.exist')
+    cy.contains('ads').should('not.exist')
+    cy.contains('France')
+    cy.contains('Spain')
+    cy.get('[id=edit-button]').click()
+    cy.get('[data-testid=RemoveCircleOutlineIcon]').first().click()
+    cy.get('[data-testid=RemoveCircleOutlineIcon]').first().click() // the two countries
+    cy.get('[id=write-button]').click()
+    cy.contains('prs').should('not.exist')
+    cy.contains('ads').should('not.exist')
+    cy.contains('France').should('not.exist')
+    cy.contains('Spain').should('not.exist')
+  })
+})

--- a/cypress/e2e/region.cy.js
+++ b/cypress/e2e/region.cy.js
@@ -47,12 +47,15 @@ describe('Editing a region', () => {
     cy.get('[data-cy=detailview-button-AD]').click()
     cy.contains('Close').click()
     cy.contains('ads')
-    //cy.get('Add new Country').click()
+    cy.get('[id=country-multiselect]').click()
+    cy.contains('Algeria').click()
+    cy.get('[id=country-add-button]').click()
     cy.get('[id=write-button]').click()
     cy.contains('prs')
     cy.contains('ads')
     cy.contains('France')
     cy.contains('Spain')
+    cy.contains('Algeria')
   })
 
   it('without any regional coordinators or countries works', () => {
@@ -73,11 +76,23 @@ describe('Editing a region', () => {
     cy.contains('Spain')
     cy.get('[id=edit-button]').click()
     cy.get('[data-testid=RemoveCircleOutlineIcon]').first().click()
-    cy.get('[data-testid=RemoveCircleOutlineIcon]').first().click() // the two countries
+    cy.get('[data-testid=RemoveCircleOutlineIcon]').first().click()
+    cy.get('[data-testid=RemoveCircleOutlineIcon]').first().click() // the three countries
     cy.get('[id=write-button]').click()
     cy.contains('prs').should('not.exist')
     cy.contains('ads').should('not.exist')
+    cy.contains('Algeria').should('not.exist')
     cy.contains('France').should('not.exist')
     cy.contains('Spain').should('not.exist')
+  })
+
+  it('add country button is disabled for invalid or empty countries', () => {
+    cy.visit(`/region/1?tab=0`)
+    cy.contains('region 4452477e')
+    cy.get('[id=edit-button]').click()
+    cy.get('[id=country-multiselect]').type('Invalid Country')
+    cy.get('[id=country-add-button]').should('be.disabled')
+    cy.get('[id=country-multiselect]').clear()
+    cy.get('[id=country-add-button]').should('be.disabled')
   })
 })

--- a/frontend/src/components/Region/RegionDetails.tsx
+++ b/frontend/src/components/Region/RegionDetails.tsx
@@ -16,9 +16,8 @@ export const RegionDetails = () => {
 
   if (isError) return <div>Error loading data</div>
   if (isLoading || !data || mutationLoading) return <CircularProgress />
-  if (data) {
-    document.title = `${data.region}`
-  }
+
+  document.title = data.region
 
   const onWrite = async (editData: EditDataType<RegionDetailsType>) => {
     try {

--- a/frontend/src/components/Region/Tabs/CoordinatorTab.tsx
+++ b/frontend/src/components/Region/Tabs/CoordinatorTab.tsx
@@ -17,15 +17,11 @@ import { useGetAllPersonsQuery } from '@/redux/personReducer'
 import { skipToken } from '@reduxjs/toolkit/query'
 import { useEffect, useMemo } from 'react'
 import { formatLastLoginDate } from '@/common'
-import Prisma from '../../../../../backend/prisma/generated/now_test_client'
+import { CircularProgress, Box } from '@mui/material'
 
 export const CoordinatorTab = () => {
   const { mode, editData, setEditData } = useDetailContext<RegionDetailsWithComPeople>()
-  const { data: personsData, isError } = useGetAllPersonsQuery(mode.read ? skipToken : undefined)
-
-  useEffect(() => {
-    console.log(personsData)
-  })
+  const { data: personsData, isLoading, isError } = useGetAllPersonsQuery(mode.read ? skipToken : undefined)
 
   const personColumns = useMemo<MRT_ColumnDef<PersonDetailsType>[]>(
     () => [
@@ -103,7 +99,13 @@ export const CoordinatorTab = () => {
     },
   ]
 
+  if (isLoading) return <CircularProgress />
+
   console.log(editData)
+
+  const formFields: { name: string; label: string; required?: boolean }[] = [
+    { name: 'country', label: 'Country', required: true },
+  ]
 
   // TODO: Selecting existing User or Country
   return (
@@ -142,6 +144,27 @@ export const CoordinatorTab = () => {
         />
       </Grouped>
       <Grouped title="Countries">
+        {!mode.read && (
+          <Box display="flex" gap={1}>
+            <EditingForm<RegionCountry, RegionDetails>
+              buttonText="Add new Country"
+              formFields={formFields}
+              editAction={(newCountry: RegionCountry) => {
+                setEditData({
+                  ...editData,
+                  now_reg_coord_country: [
+                    ...editData.now_reg_coord_country,
+                    {
+                      reg_coord_id: editData.reg_coord_id,
+                      country: newCountry.country,
+                      rowState: 'new',
+                    },
+                  ],
+                })
+              }}
+            />
+          </Box>
+        )}
         <EditableTable<RegionCountry, RegionDetails>
           columns={country}
           editTableData={editData.now_reg_coord_country}

--- a/frontend/src/components/Region/Tabs/CoordinatorTab.tsx
+++ b/frontend/src/components/Region/Tabs/CoordinatorTab.tsx
@@ -63,7 +63,7 @@ export const CoordinatorTab = () => {
           id={'country-add-button'}
           sx={{ maxHeight: '4em' }}
           variant="contained"
-          disabled={!!countryError}
+          disabled={!!countryError || !dropdownValue}
           onClick={() => void onSave()}
         >
           Save

--- a/frontend/src/components/Region/Tabs/CoordinatorTab.tsx
+++ b/frontend/src/components/Region/Tabs/CoordinatorTab.tsx
@@ -2,8 +2,6 @@ import {
   RegionDetails,
   RegionCoordinator,
   RegionCountry,
-  Region,
-  User,
   PersonDetailsType,
   RegionDetailsWithComPeople,
 } from '@/shared/types'
@@ -15,7 +13,7 @@ import { SelectingTable } from '@/components/DetailView/common/SelectingTable'
 import { EditingForm } from '@/components/DetailView/common/EditingForm'
 import { useGetAllPersonsQuery } from '@/redux/personReducer'
 import { skipToken } from '@reduxjs/toolkit/query'
-import { useEffect, useMemo } from 'react'
+import { useMemo } from 'react'
 import { formatLastLoginDate } from '@/common'
 import { CircularProgress, Box } from '@mui/material'
 
@@ -27,6 +25,7 @@ export const CoordinatorTab = () => {
     () => [
       {
         accessorKey: 'initials',
+        id: 'person_id',
         header: 'Person Id',
       },
       {
@@ -100,8 +99,6 @@ export const CoordinatorTab = () => {
   ]
 
   if (isLoading) return <CircularProgress />
-
-  console.log(editData)
 
   const formFields: { name: string; label: string; required?: boolean }[] = [
     { name: 'country', label: 'Country', required: true },

--- a/frontend/src/components/Region/Tabs/CoordinatorTab.tsx
+++ b/frontend/src/components/Region/Tabs/CoordinatorTab.tsx
@@ -104,7 +104,6 @@ export const CoordinatorTab = () => {
     { name: 'country', label: 'Country', required: true },
   ]
 
-  // TODO: Selecting existing User or Country
   return (
     <>
       <Grouped title="Regional Coordinators">

--- a/frontend/src/shared/types/data.ts
+++ b/frontend/src/shared/types/data.ts
@@ -194,6 +194,13 @@ export type RegionDetails = Prisma.now_reg_coord & { now_reg_coord_people: Array
   now_reg_coord_country: Array<RegionCountry>
 }
 
+// used in Region's CoordinatorTab to allow adding com_people field to the editData manually
+export type RegionDetailsWithComPeople = Prisma.now_reg_coord & {
+  now_reg_coord_people: Array<RegionCoordinator & { com_people?: Prisma.com_people }>
+} & {
+  now_reg_coord_country: Array<RegionCountry>
+}
+
 export type TimeBound = {
   bid: number
   b_name: string

--- a/frontend/src/shared/validators/region.ts
+++ b/frontend/src/shared/validators/region.ts
@@ -3,12 +3,12 @@ import { Validators, validator, ValidationError } from './validator'
 
 const countryCheck = (countries: EditDataType<RegionCountry[]>) => {
   for (const country of countries) {
-    if (!('country' in country) || typeof country.country !== 'string') {
+    if (!('country' in country) || typeof country.country !== 'string' || country.country === '') {
       return 'Invalid or missing country field in region countries'
     }
   }
   const uniqueCountries = new Set(countries.map(country => country.country!))
-  if (uniqueCountries.size !== countries.length) return 'Duplicate country name in region countries'
+  if (uniqueCountries.size !== countries.length) return 'Duplicate country in country list'
   return null as ValidationError
 }
 

--- a/frontend/src/shared/validators/region.ts
+++ b/frontend/src/shared/validators/region.ts
@@ -7,6 +7,8 @@ const countryCheck = (countries: EditDataType<RegionCountry[]>) => {
       return 'Invalid or missing country field in region countries'
     }
   }
+  const uniqueCountries = new Set(countries.map(country => country.country!))
+  if (uniqueCountries.size !== countries.length) return 'Duplicate country name in region countries'
   return null as ValidationError
 }
 


### PR DESCRIPTION
I made a new type called `RegionDetailsWithComPeople` that is used in Region's CoordinatorTab to allow adding the com_people field to the editData manually in the SelectingTables. Not sure if this is the best way to deal with the issue.

This PR also doesn't have anything related to creating new regions, I will look at that later.