### PR TITLE
fix id error in person table

### DIFF
--- a/frontend/src/components/Person/PersonTable.tsx
+++ b/frontend/src/components/Person/PersonTable.tsx
@@ -11,6 +11,7 @@ export const PersonTable = ({ selectorFn }: { selectorFn?: (id: PersonDetailsTyp
     () => [
       {
         accessorKey: 'initials',
+        id: 'person_id',
         header: 'Person Id',
       },
       {


### PR DESCRIPTION
There are two columns with the same accessorKey and thus the same id in PersonTable. This caused a lot of error messages and weird things to happen when showing/hiding columns, so I added an additional id value to one of them.