### PR TITLE
add express-rate-limit for email rate limiting

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -23,6 +23,7 @@
         "cors": "^2.8.5",
         "express": "^4.18.2",
         "express-async-errors": "^3.1.1",
+        "express-rate-limit": "^7.5.0",
         "jsonwebtoken": "^9.0.2",
         "mariadb": "^3.3.0",
         "md5": "^2.3.0",
@@ -6342,6 +6343,21 @@
       "integrity": "sha512-h6aK1da4tpqWSbyCa3FxB/V6Ehd4EEB15zyQq9qe75OZBp0krinNKuH4rAY+S/U/2I36vdLAUFSjQJ+TFmODng==",
       "peerDependencies": {
         "express": "^4.16.2"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
+      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": "^4.11 || 5 || ^5.0.0-beta.1"
       }
     },
     "node_modules/fast-deep-equal": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -52,6 +52,7 @@
     "cors": "^2.8.5",
     "express": "^4.18.2",
     "express-async-errors": "^3.1.1",
+    "express-rate-limit": "^7.5.0",
     "jsonwebtoken": "^9.0.2",
     "mariadb": "^3.3.0",
     "md5": "^2.3.0",

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -15,7 +15,7 @@ import refreshTokenRouter from './routes/refresh'
 import timeBoundRouter from './routes/timeBound'
 import timeUnitRouter from './routes/timeUnit'
 import userRouter from './routes/user'
-import emailRouter from './routes/email'
+import emailRouter, { emailLimiter } from './routes/email'
 import versionRouter from './routes/version'
 import geonamesRouter from './routes/geonames-api'
 import { responseLogger } from './middlewares/requestLogger'
@@ -27,7 +27,6 @@ import { requireOneOf } from './middlewares/authorizer'
 import { Role } from './../../frontend/src/shared/types'
 import { blockWriteRequests } from './middlewares/misc'
 import testRouter from './routes/test'
-import { rateLimit } from 'express-rate-limit'
 
 const app = express()
 
@@ -46,15 +45,7 @@ app.use(refreshTokenRouter)
 app.use(tokenExtractor)
 app.use(userExtractor)
 
-const limiter = rateLimit({
-  windowMs: 15 * 1000,
-  limit: 1,
-  standardHeaders: true,
-  legacyHeaders: false,
-  message: { message: 'You have sent an email recently, please try again in a few seconds.' },
-})
-
-app.use('/email', limiter)
+app.use('/email', emailLimiter)
 
 app.use('/user', userRouter)
 app.use('/crosssearch', crossSearchRouter)

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -27,6 +27,7 @@ import { requireOneOf } from './middlewares/authorizer'
 import { Role } from './../../frontend/src/shared/types'
 import { blockWriteRequests } from './middlewares/misc'
 import testRouter from './routes/test'
+import { rateLimit } from 'express-rate-limit'
 
 const app = express()
 
@@ -44,6 +45,16 @@ app.use(refreshTokenRouter)
 
 app.use(tokenExtractor)
 app.use(userExtractor)
+
+const limiter = rateLimit({
+  windowMs: 15 * 1000,
+  limit: 1,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { message: 'You have sent an email recently, please try again in a few seconds.' },
+})
+
+app.use('/email', limiter)
 
 app.use('/user', userRouter)
 app.use('/crosssearch', crossSearchRouter)

--- a/backend/src/routes/email.ts
+++ b/backend/src/routes/email.ts
@@ -10,6 +10,15 @@ import {
 } from '../utils/config'
 import { logger } from '../utils/logger'
 import { sleep } from '../utils/common'
+import { rateLimit } from 'express-rate-limit'
+
+export const emailLimiter = rateLimit({
+  windowMs: 15 * 1000,
+  limit: 1,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { message: 'You have sent an email recently, please try again in a few seconds.' },
+})
 
 const router = Router()
 

--- a/backend/src/routes/email.ts
+++ b/backend/src/routes/email.ts
@@ -13,8 +13,6 @@ import { sleep } from '../utils/common'
 
 const router = Router()
 
-let emailSent: Date | null = null
-
 const transport =
   RUNNING_ENV === 'prod'
     ? createTransport({
@@ -32,10 +30,6 @@ router.post('/', async (req: Request<object, object, { title: string; message: s
     logger.info(`Would have sent email with following data: \n${JSON.stringify({ title, message }, null, 2)}`)
     return res.status(200).json()
   }
-  if (emailSent && new Date().getTime() - emailSent.getTime() < 60000) {
-    return res.status(400).json({ message: 'Email already sent in last minute.' })
-  }
-  emailSent = new Date()
   if (!CONTACT_FROM_NAME || !CONTACT_FROM_EMAIL || !CONTACT_SMTP_HOST || !CONTACT_SMTP_PORT || !CONTACT_RECIPIENT) {
     return res.status(500).json({ message: 'Server is missing configurations for sending emails.' })
   }

--- a/documentation/backend/rate_limiting_for_emails.md
+++ b/documentation/backend/rate_limiting_for_emails.md
@@ -1,0 +1,5 @@
+### Rate Limiting For Emails
+
+The app uses [express-rate-limit](https://www.npmjs.com/package/express-rate-limit) middleware to limit the use of the email route. This is to avoid users spamming emails.
+
+The rate limiting is done on a per-user basis and uses the IP address of the user for this. The limit is set inside the [app.ts](../../backend/src/app.ts) file. Currently, the settings allow one email every 15 seconds (per user).

--- a/documentation/backend/rate_limiting_for_emails.md
+++ b/documentation/backend/rate_limiting_for_emails.md
@@ -2,4 +2,4 @@
 
 The app uses [express-rate-limit](https://www.npmjs.com/package/express-rate-limit) middleware to limit the use of the email route. This is to avoid users spamming emails.
 
-The rate limiting is done on a per-user basis and uses the IP address of the user for this. The limit is set inside the [app.ts](../../backend/src/app.ts) file. Currently, the settings allow one email every 15 seconds (per user).
+The rate limiting is done on a per-user basis and uses the IP address of the user for this. The limit is set inside the [email](../../backend/src/routes/email.ts) route file. Currently, the settings allow one email every 15 seconds (per user).


### PR DESCRIPTION
Also modified the contact form notification to show user when the limit is reached.

Currently the limiter is defined inside app.ts, I'm not sure if it should be there or inside the email.ts route file but I chose this for now.

The limiter should allow one email every 15 seconds, per user. However, this should be tested in production since getting the IP address of users might work differently there compared to local testing.