### PR TITLE
hide red error box when not in edit mode

### DIFF
--- a/frontend/src/components/DetailView/DetailView.tsx
+++ b/frontend/src/components/DetailView/DetailView.tsx
@@ -217,7 +217,7 @@ export const DetailView = <T extends object>({
                 Delete
               </Button>
             )}
-            {Object.keys(fieldsWithErrors).length > 0 && <ErrorBox />}
+            {!mode.read && Object.keys(fieldsWithErrors).length > 0 && <ErrorBox />}
             {(!mode.read || initialState.mode.new) && onWrite && (
               <WriteButton onWrite={onWrite} hasStagingMode={hasStagingMode} />
             )}


### PR DESCRIPTION
Currently if you edit an item and remove a required field from it, then click "cancel edit", the big red error box stays visible which is pretty confusing. This is a simple fix for that.