### PR TITLE
Fixed bug where locality details query breaks on certain species

### DIFF
--- a/backend/src/services/species.ts
+++ b/backend/src/services/species.ts
@@ -80,9 +80,9 @@ export const getSpeciesDetails = async (id: number) => {
       now_sau: {
         include: {
           now_sr: {
-            include: {
+            select: {
               ref_ref: {
-                include: {
+                select: {
                   ref_authors: true,
                   ref_journal: true,
                 },

--- a/backend/src/services/species.ts
+++ b/backend/src/services/species.ts
@@ -87,6 +87,7 @@ export const getSpeciesDetails = async (id: number) => {
                   ref_journal: true,
                 },
               },
+              rid: true,
             },
           },
         },


### PR DESCRIPTION
Species with `ref_ref.exact_date = NULL`