### PR TITLE
Display password requirements on change password form

### DIFF
--- a/frontend/src/components/Person/Tabs/ChangePasswordForm.tsx
+++ b/frontend/src/components/Person/Tabs/ChangePasswordForm.tsx
@@ -1,7 +1,7 @@
 import { useNotify } from '@/hooks/notification'
 import { removeFirstLogin, useChangePasswordMutation } from '@/redux/userReducer'
-import { Button, Grid, TextField } from '@mui/material'
-import { useState } from 'react'
+import { Button, Grid, List, ListItem, ListItemText, TextField, Typography } from '@mui/material'
+import { useMemo, useState } from 'react'
 import { useDispatch } from 'react-redux'
 
 type ChangePasswordError = { status: number; data: { error: string } }
@@ -14,6 +14,14 @@ export const ChangePasswordForm = () => {
   const { notify } = useNotify()
   const sx = { display: 'flex', alignItems: 'center', width: '10em', fontWeight: 'bold' }
   const dispatch = useDispatch()
+
+  const passwordRequirements = useMemo(
+    () => [
+      'Password must be at least 8 characters long',
+      'Password must only contain characters a-z, A-Z, 0-9 and ^?$%&~!',
+    ],
+    []
+  )
 
   const changePassword = async () => {
     if (newPassword !== verifyPassword) {
@@ -71,6 +79,16 @@ export const ChangePasswordForm = () => {
           value={verifyPassword}
           onChange={event => setVerifyPassword(event.target.value)}
         />
+      </Grid>
+      <Grid container direction="column" sx={{ rowGap: '0.5em' }}>
+        <Typography variant="subtitle1">Password requirements</Typography>
+        <List dense sx={{ listStyleType: 'disc', pl: 4 }}>
+          {passwordRequirements.map(requirement => (
+            <ListItem key={requirement} sx={{ display: 'list-item', py: 0 }}>
+              <ListItemText primary={requirement} />
+            </ListItem>
+          ))}
+        </List>
       </Grid>
       <Grid container direction="row">
         <Grid item width="27em">

--- a/frontend/tests/components/ChangePasswordForm.test.tsx
+++ b/frontend/tests/components/ChangePasswordForm.test.tsx
@@ -1,0 +1,37 @@
+import { describe, expect, it, jest } from '@jest/globals'
+import { render, screen } from '@testing-library/react'
+
+import '@testing-library/jest-dom'
+import { ChangePasswordForm } from '@/components/Person/Tabs/ChangePasswordForm'
+
+jest.mock('@/hooks/notification', () => ({
+  useNotify: () => ({
+    notify: jest.fn(),
+    setMessage: jest.fn(),
+  }),
+}))
+
+jest.mock('@/redux/userReducer', () => ({
+  useChangePasswordMutation: () => [jest.fn(), {}],
+  removeFirstLogin: jest.fn(),
+}))
+
+jest.mock('react-redux', () => ({
+  useDispatch: () => jest.fn(),
+}))
+
+describe('ChangePasswordForm', () => {
+  it('shows password requirements before submission', () => {
+    render(<ChangePasswordForm />)
+
+    const requirementsHeading = screen.getByText('Password requirements')
+    const minLengthRequirement = screen.getByText('Password must be at least 8 characters long')
+    const allowedCharactersRequirement = screen.getByText(
+      'Password must only contain characters a-z, A-Z, 0-9 and ^?$%&~!'
+    )
+
+    expect(requirementsHeading).toBeDefined()
+    expect(minLengthRequirement).toBeDefined()
+    expect(allowedCharactersRequirement).toBeDefined()
+  })
+})


### PR DESCRIPTION
## Summary
- surface password requirements inline on the change password form
- reuse consistent requirement copy for visibility before submission
- add a component test ensuring the requirements render

## Testing
- npm run lint
- npm run tsc

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692da17b14fc8329a089036da6b812ec)