### PR TITLE
Add unsaved changes prompts to locality forms

### DIFF
--- a/frontend/src/api/localitiesApi.ts
+++ b/frontend/src/api/localitiesApi.ts
@@ -1,0 +1,24 @@
+import type { EditDataType, LocalityDetailsType } from '@/shared/types'
+import type { LocalityFormValues } from '@/components/Locality/LocalityForm'
+
+const toCoordinateString = (value: number | null | undefined) => (typeof value === 'number' ? value.toString() : '')
+
+export const localityDetailsToFormValues = (locality: LocalityDetailsType): LocalityFormValues => ({
+  localityName: locality.loc_name ?? '',
+  country: locality.country ?? '',
+  latitude: toCoordinateString(locality.dec_lat),
+  longitude: toCoordinateString(locality.dec_long),
+  visibility: locality.loc_status ? 'private' : 'public',
+})
+
+export const localityFormValuesToPayload = (
+  values: LocalityFormValues,
+  base: EditDataType<LocalityDetailsType>
+): EditDataType<LocalityDetailsType> => ({
+  ...base,
+  loc_name: values.localityName.trim(),
+  country: values.country.trim(),
+  dec_lat: values.latitude === '' ? undefined : Number(values.latitude),
+  dec_long: values.longitude === '' ? undefined : Number(values.longitude),
+  loc_status: values.visibility === 'private',
+})

--- a/frontend/src/components/Locality/LocalityForm.tsx
+++ b/frontend/src/components/Locality/LocalityForm.tsx
@@ -1,0 +1,184 @@
+import { useEffect, useMemo } from 'react'
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Divider,
+  FormControl,
+  FormControlLabel,
+  FormHelperText,
+  FormLabel,
+  Grid,
+  Radio,
+  RadioGroup,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material'
+import { Controller, useForm } from 'react-hook-form'
+
+import { useUnsavedChangesPrompt } from '@/hooks/useUnsavedChangesPrompt'
+
+export type LocalityFormValues = {
+  localityName: string
+  country: string
+  latitude: string
+  longitude: string
+  visibility: 'public' | 'private'
+}
+
+type LocalityFormProps = {
+  onSubmit: (values: LocalityFormValues) => Promise<void>
+  initialValues?: Partial<LocalityFormValues>
+  isSubmitting?: boolean
+  serverError?: string | null
+  submitLabel?: string
+}
+
+const normalizeValue = (value: string | undefined) => value ?? ''
+
+export const LocalityForm = ({
+  onSubmit,
+  initialValues,
+  isSubmitting = false,
+  serverError,
+  submitLabel = 'Save locality',
+}: LocalityFormProps) => {
+  const defaultValues = useMemo<LocalityFormValues>(
+    () => ({
+      localityName: normalizeValue(initialValues?.localityName),
+      country: normalizeValue(initialValues?.country),
+      latitude: normalizeValue(initialValues?.latitude),
+      longitude: normalizeValue(initialValues?.longitude),
+      visibility: initialValues?.visibility ?? 'public',
+    }),
+    [initialValues]
+  )
+
+  const {
+    control,
+    register,
+    handleSubmit,
+    formState: { errors, isDirty },
+    reset,
+  } = useForm<LocalityFormValues>({
+    defaultValues,
+  })
+
+  useEffect(() => {
+    reset(defaultValues)
+  }, [defaultValues, reset])
+
+  const { setDirty } = useUnsavedChangesPrompt(isDirty)
+
+  const submitHandler = handleSubmit(async values => {
+    try {
+      setDirty(false)
+      await onSubmit({
+        ...values,
+        localityName: values.localityName.trim(),
+        country: values.country.trim(),
+        latitude: values.latitude.trim(),
+        longitude: values.longitude.trim(),
+      })
+      setDirty(false)
+    } catch (error) {
+      setDirty(true)
+    }
+  })
+
+  return (
+    <Card
+      component="form"
+      onSubmit={event => {
+        void submitHandler(event)
+      }}
+    >
+      <CardContent>
+        <Stack spacing={4}>
+          <Stack spacing={1}>
+            <Typography variant="h5">Locality information</Typography>
+            <Divider />
+          </Stack>
+
+          <Grid container spacing={3}>
+            <Grid item xs={12} md={6}>
+              <TextField
+                label="Locality Name"
+                fullWidth
+                {...register('localityName', { required: 'Locality name is required' })}
+                error={Boolean(errors.localityName)}
+                helperText={errors.localityName?.message}
+                disabled={isSubmitting}
+              />
+            </Grid>
+            <Grid item xs={12} md={6}>
+              <TextField
+                label="Country"
+                fullWidth
+                {...register('country', { required: 'Country is required' })}
+                error={Boolean(errors.country)}
+                helperText={errors.country?.message}
+                disabled={isSubmitting}
+              />
+            </Grid>
+            <Grid item xs={12} md={6}>
+              <TextField
+                label="Latitude (decimal degrees)"
+                fullWidth
+                type="number"
+                inputProps={{ step: 'any' }}
+                {...register('latitude')}
+                error={Boolean(errors.latitude)}
+                helperText={errors.latitude?.message}
+                disabled={isSubmitting}
+              />
+            </Grid>
+            <Grid item xs={12} md={6}>
+              <TextField
+                label="Longitude (decimal degrees)"
+                fullWidth
+                type="number"
+                inputProps={{ step: 'any' }}
+                {...register('longitude')}
+                error={Boolean(errors.longitude)}
+                helperText={errors.longitude?.message}
+                disabled={isSubmitting}
+              />
+            </Grid>
+            <Grid item xs={12}>
+              <FormControl component="fieldset" disabled={isSubmitting}>
+                <FormLabel component="legend">Visibility</FormLabel>
+                <Controller
+                  name="visibility"
+                  control={control}
+                  render={({ field }) => (
+                    <RadioGroup row {...field}>
+                      <FormControlLabel value="public" control={<Radio />} label="Public" />
+                      <FormControlLabel value="private" control={<Radio />} label="Private" />
+                    </RadioGroup>
+                  )}
+                />
+                <FormHelperText>
+                  Choose whether this locality should be visible to all users or restricted.
+                </FormHelperText>
+              </FormControl>
+            </Grid>
+          </Grid>
+
+          {serverError ? <Alert severity="error">{serverError}</Alert> : null}
+
+          <Box display="flex" justifyContent="flex-end" gap={2} alignItems="center">
+            <Button variant="contained" type="submit" disabled={isSubmitting}>
+              {submitLabel}
+            </Button>
+          </Box>
+        </Stack>
+      </CardContent>
+    </Card>
+  )
+}
+
+export default LocalityForm

--- a/frontend/src/components/UnsavedChangesProvider.tsx
+++ b/frontend/src/components/UnsavedChangesProvider.tsx
@@ -1,0 +1,89 @@
+import type { ReactNode } from 'react'
+import { createContext, useContext, useEffect, useMemo, useState } from 'react'
+import { Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle } from '@mui/material'
+import type { Blocker } from '@remix-run/router'
+import { useBlocker } from 'react-router-dom'
+
+type UnsavedChangesContextValue = {
+  isDirty: boolean
+  setDirty: (dirty: boolean) => void
+}
+
+const UnsavedChangesContext = createContext<UnsavedChangesContextValue | null>(null)
+
+const shouldShowPrompt = (blocker: Blocker, isDirty: boolean) => blocker.state === 'blocked' && isDirty
+
+export const UnsavedChangesProvider = ({ children }: { children: ReactNode }) => {
+  const [isDirty, setDirty] = useState(false)
+  const blocker = useBlocker(isDirty)
+  const [dialogOpen, setDialogOpen] = useState(false)
+
+  useEffect(() => {
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (!isDirty) return
+      event.preventDefault()
+      event.returnValue = ''
+    }
+
+    if (isDirty) {
+      window.addEventListener('beforeunload', handleBeforeUnload)
+    }
+
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload)
+  }, [isDirty])
+
+  useEffect(() => {
+    setDialogOpen(shouldShowPrompt(blocker, isDirty))
+  }, [blocker, isDirty])
+
+  const handleStay = () => {
+    blocker.reset?.()
+    setDialogOpen(false)
+  }
+
+  const handleLeave = () => {
+    setDirty(false)
+    blocker.proceed?.()
+    setDialogOpen(false)
+  }
+
+  const contextValue = useMemo<UnsavedChangesContextValue>(() => ({ isDirty, setDirty }), [isDirty])
+
+  return (
+    <UnsavedChangesContext.Provider value={contextValue}>
+      {children}
+      <Dialog
+        open={dialogOpen}
+        aria-labelledby="unsaved-changes-title"
+        aria-describedby="unsaved-changes-description"
+        onClose={handleStay}
+      >
+        <DialogTitle id="unsaved-changes-title">Unsaved changes</DialogTitle>
+        <DialogContent>
+          <DialogContentText id="unsaved-changes-description">
+            You have unsaved changes. If you leave now, your edits will be lost.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleStay} color="primary" variant="outlined">
+            Stay on page
+          </Button>
+          <Button onClick={handleLeave} color="error" variant="contained" autoFocus>
+            Leave page
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </UnsavedChangesContext.Provider>
+  )
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const useUnsavedChangesContext = () => {
+  const context = useContext(UnsavedChangesContext)
+  if (!context) {
+    throw new Error('useUnsavedChangesContext must be used within an UnsavedChangesProvider')
+  }
+  return context
+}
+
+export default UnsavedChangesProvider

--- a/frontend/src/hooks/useUnsavedChangesPrompt.ts
+++ b/frontend/src/hooks/useUnsavedChangesPrompt.ts
@@ -1,0 +1,15 @@
+import { useEffect } from 'react'
+
+import { useUnsavedChangesContext } from '@/components/UnsavedChangesProvider'
+
+export const useUnsavedChangesPrompt = (isDirty: boolean) => {
+  const { setDirty } = useUnsavedChangesContext()
+
+  useEffect(() => {
+    setDirty(isDirty)
+  }, [isDirty, setDirty])
+
+  return { setDirty }
+}
+
+export default useUnsavedChangesPrompt

--- a/frontend/src/pages/localities/LocalityCreatePage.tsx
+++ b/frontend/src/pages/localities/LocalityCreatePage.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useState } from 'react'
+import { Link as RouterLink, useNavigate } from 'react-router-dom'
+import { Button, Stack, Typography } from '@mui/material'
+
+import { LocalityForm, LocalityFormValues } from '@/components/Locality/LocalityForm'
+import { UnsavedChangesProvider } from '@/components/UnsavedChangesProvider'
+import { localityFormValuesToPayload } from '@/api/localitiesApi'
+import { emptyLocality } from '@/components/DetailView/common/defaultValues'
+import { useEditLocalityMutation } from '@/redux/localityReducer'
+import { useNotify } from '@/hooks/notification'
+
+export const LocalityCreatePage = () => {
+  const { notify } = useNotify()
+  const navigate = useNavigate()
+  const [submitError, setSubmitError] = useState<string | null>(null)
+  const [createLocality, { isLoading }] = useEditLocalityMutation()
+
+  useEffect(() => {
+    document.title = 'Create locality'
+  }, [])
+
+  const handleSubmit = async (values: LocalityFormValues) => {
+    setSubmitError(null)
+    try {
+      const payload = localityFormValuesToPayload(values, { ...emptyLocality })
+      const response = await createLocality(payload).unwrap()
+      const newId = (response as { id?: number } | undefined)?.id
+      notify('Locality created successfully.')
+      navigate(newId ? `/locality/${newId}` : '/locality')
+    } catch (error) {
+      setSubmitError('Failed to create locality.')
+      throw error
+    }
+  }
+
+  return (
+    <UnsavedChangesProvider>
+      <Stack spacing={3} sx={{ maxWidth: 960, margin: '0 auto' }}>
+        <Stack direction="row" justifyContent="space-between" alignItems="center">
+          <Stack spacing={0.5}>
+            <Typography variant="h4" component="h1">
+              Create locality
+            </Typography>
+            <Typography color="text.secondary">Enter the basic information needed to add a new locality.</Typography>
+          </Stack>
+          <Button component={RouterLink} to="/locality" variant="text">
+            Back to localities
+          </Button>
+        </Stack>
+
+        <LocalityForm
+          onSubmit={handleSubmit}
+          isSubmitting={isLoading}
+          serverError={submitError}
+          submitLabel="Create locality"
+        />
+      </Stack>
+    </UnsavedChangesProvider>
+  )
+}
+
+export default LocalityCreatePage

--- a/frontend/src/pages/localities/LocalityEditPage.tsx
+++ b/frontend/src/pages/localities/LocalityEditPage.tsx
@@ -1,0 +1,108 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Link as RouterLink, useNavigate, useParams } from 'react-router-dom'
+import { Button, CircularProgress, Stack, Typography } from '@mui/material'
+
+import { LocalityForm, LocalityFormValues } from '@/components/Locality/LocalityForm'
+import { UnsavedChangesProvider } from '@/components/UnsavedChangesProvider'
+import { localityDetailsToFormValues, localityFormValuesToPayload } from '@/api/localitiesApi'
+import { useGetLocalityDetailsQuery, useEditLocalityMutation } from '@/redux/localityReducer'
+import { useNotify } from '@/hooks/notification'
+
+export const LocalityEditPage = () => {
+  const { id } = useParams()
+  const localityId = id ? Number(id) : null
+  const navigate = useNavigate()
+  const { notify } = useNotify()
+  const [submitError, setSubmitError] = useState<string | null>(null)
+  const [updateLocality, { isLoading: isUpdating }] = useEditLocalityMutation()
+
+  const { data, isFetching, isError, refetch } = useGetLocalityDetailsQuery(id ?? '', {
+    skip: !id,
+  })
+
+  useEffect(() => {
+    if (data?.loc_name) {
+      document.title = `Edit locality - ${data.loc_name}`
+    }
+  }, [data])
+
+  const initialValues = useMemo(() => (data ? localityDetailsToFormValues(data) : null), [data])
+
+  const handleSubmit = async (values: LocalityFormValues) => {
+    if (!data || !localityId) return
+    setSubmitError(null)
+    try {
+      const payload = localityFormValuesToPayload(values, { ...data })
+      await updateLocality(payload).unwrap()
+      notify('Locality updated successfully.')
+      navigate(`/locality/${localityId}`)
+    } catch (error) {
+      setSubmitError('Failed to update locality.')
+      throw error
+    }
+  }
+
+  if (!localityId) {
+    return <Typography>Locality not found.</Typography>
+  }
+
+  if (isError || !data) {
+    return (
+      <Stack spacing={2} alignItems="center" sx={{ mt: 4 }}>
+        <Typography>Unable to load locality.</Typography>
+        <Button
+          variant="contained"
+          onClick={() => {
+            void refetch()
+          }}
+        >
+          Retry
+        </Button>
+      </Stack>
+    )
+  }
+
+  if (isFetching || !initialValues) {
+    return (
+      <Stack alignItems="center" justifyContent="center" spacing={2} sx={{ mt: 4 }}>
+        <CircularProgress />
+        <Typography>Loading locality...</Typography>
+      </Stack>
+    )
+  }
+
+  return (
+    <UnsavedChangesProvider>
+      <Stack spacing={3} sx={{ maxWidth: 960, margin: '0 auto' }}>
+        <Stack direction="row" justifyContent="space-between" alignItems="center">
+          <Stack spacing={0.5}>
+            <Typography variant="h4" component="h1">
+              Edit locality
+            </Typography>
+            <Typography color="text.secondary">
+              Update the locality details and navigate away safely once you are done.
+            </Typography>
+          </Stack>
+          <Stack direction="row" spacing={1}>
+            <Button component={RouterLink} to="/locality" variant="text">
+              Back to localities
+            </Button>
+            <Button component={RouterLink} to={`/locality/${localityId}`} variant="outlined">
+              Return to locality
+            </Button>
+          </Stack>
+        </Stack>
+
+        <LocalityForm
+          initialValues={initialValues ?? undefined}
+          onSubmit={handleSubmit}
+          isSubmitting={isUpdating}
+          serverError={submitError}
+          submitLabel="Save changes"
+        />
+      </Stack>
+    </UnsavedChangesProvider>
+  )
+}
+
+export default LocalityEditPage

--- a/frontend/src/tests/pages/LocalityEditPage.test.tsx
+++ b/frontend/src/tests/pages/LocalityEditPage.test.tsx
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals'
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { LocalityEditPage } from '@/pages/localities/LocalityEditPage'
+import type { LocalityDetailsType } from '@/shared/types'
+import { emptyLocality } from '@/components/DetailView/common/defaultValues'
+
+const mockUpdateLocality = jest.fn()
+const mockNotify = jest.fn()
+const mockRefetch = jest.fn()
+
+const baseLocality: LocalityDetailsType = {
+  ...emptyLocality,
+  lid: 42,
+  loc_name: 'Existing locality',
+  country: 'Finland',
+  dec_lat: 60,
+  dec_long: 25,
+}
+
+const mockUseGetLocalityDetailsQuery = jest.fn()
+
+jest.mock('@/redux/localityReducer', () => ({
+  useEditLocalityMutation: () => [mockUpdateLocality, { isLoading: false }],
+  useGetLocalityDetailsQuery: (arg: unknown) => mockUseGetLocalityDetailsQuery(arg),
+}))
+
+jest.mock('@/hooks/notification', () => ({
+  useNotify: () => ({ notify: mockNotify }),
+}))
+
+const LocationDisplay = () => {
+  const location = useLocation()
+  return <div data-testid="location">{location.pathname}</div>
+}
+
+const renderWithRouter = () =>
+  render(
+    <MemoryRouter initialEntries={['/localities/42/edit']}>
+      <Routes>
+        <Route
+          path="/localities/:id/edit"
+          element={
+            <>
+              <LocationDisplay />
+              <LocalityEditPage />
+            </>
+          }
+        />
+        <Route path="/locality/:id" element={<div>Locality detail</div>} />
+        <Route path="/locality" element={<div>Locality list</div>} />
+      </Routes>
+    </MemoryRouter>
+  )
+
+describe('LocalityEditPage unsaved changes prompts', () => {
+  beforeEach(() => {
+    mockUpdateLocality.mockReturnValue({ unwrap: () => Promise.resolve({ id: 42 }) })
+    mockUseGetLocalityDetailsQuery.mockReturnValue({
+      data: baseLocality,
+      isFetching: false,
+      isError: false,
+      refetch: mockRefetch,
+    })
+    mockNotify.mockReset()
+  })
+
+  it('shows a blocker when navigating away with dirty changes and cancelling keeps the user on the page', async () => {
+    const user = userEvent.setup()
+    renderWithRouter()
+
+    await user.clear(screen.getByLabelText('Locality Name'))
+    await user.type(screen.getByLabelText('Locality Name'), 'Updated name')
+
+    await user.click(screen.getByRole('button', { name: /return to locality/i }))
+
+    expect(await screen.findByText(/unsaved changes/i)).toBeTruthy()
+
+    await user.click(screen.getByRole('button', { name: /stay on page/i }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('location').textContent).toBe('/localities/42/edit')
+    })
+  })
+
+  it('allows navigation away after confirming leave on dirty form', async () => {
+    const user = userEvent.setup()
+    renderWithRouter()
+
+    await user.type(screen.getByLabelText('Country'), ' update')
+    await user.click(screen.getByRole('button', { name: /back to localities/i }))
+
+    expect(await screen.findByText(/unsaved changes/i)).toBeTruthy()
+
+    await user.click(screen.getByRole('button', { name: /leave page/i }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('location').textContent).toBe('/locality')
+    })
+  })
+
+  it('navigates without prompting when no changes were made', async () => {
+    const user = userEvent.setup()
+    renderWithRouter()
+
+    await user.click(screen.getByRole('button', { name: /return to locality/i }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('location').textContent).toBe('/locality/42')
+    })
+    expect(screen.queryByText(/unsaved changes/i)).toBeNull()
+  })
+})

--- a/frontend/src/tests/pages/LocalityNewPage.test.tsx
+++ b/frontend/src/tests/pages/LocalityNewPage.test.tsx
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals'
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { LocalityCreatePage } from '@/pages/localities/LocalityCreatePage'
+
+const mockNotify = jest.fn()
+const mockCreateLocality = jest.fn()
+
+jest.mock('@/redux/localityReducer', () => ({
+  useEditLocalityMutation: () => [mockCreateLocality, { isLoading: false }],
+}))
+
+jest.mock('@/hooks/notification', () => ({
+  useNotify: () => ({ notify: mockNotify }),
+}))
+
+const LocationDisplay = () => {
+  const location = useLocation()
+  return <div data-testid="location">{location.pathname}</div>
+}
+
+const renderWithRouter = () =>
+  render(
+    <MemoryRouter initialEntries={['/localities/new']}>
+      <Routes>
+        <Route
+          path="/localities/new"
+          element={
+            <>
+              <LocationDisplay />
+              <LocalityCreatePage />
+            </>
+          }
+        />
+        <Route path="/locality" element={<div>Locality list</div>} />
+      </Routes>
+    </MemoryRouter>
+  )
+
+describe('LocalityCreatePage unsaved changes prompts', () => {
+  beforeEach(() => {
+    mockNotify.mockReset()
+    mockCreateLocality.mockReturnValue({ unwrap: () => Promise.resolve({ id: 101 }) })
+  })
+
+  it('blocks navigation with a dialog when the form is dirty and the user cancels', async () => {
+    const user = userEvent.setup()
+    renderWithRouter()
+
+    await user.type(screen.getByLabelText('Locality Name'), 'Test Locality')
+
+    await user.click(screen.getByRole('button', { name: /back to localities/i }))
+
+    expect(await screen.findByText(/unsaved changes/i)).toBeTruthy()
+
+    await user.click(screen.getByRole('button', { name: /stay on page/i }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('location').textContent).toBe('/localities/new')
+    })
+    expect(screen.queryByText(/unsaved changes/i)).toBeNull()
+  })
+
+  it('navigates away when the user confirms leaving with dirty changes', async () => {
+    const user = userEvent.setup()
+    renderWithRouter()
+
+    await user.type(screen.getByLabelText('Locality Name'), 'Test Locality')
+    await user.click(screen.getByRole('button', { name: /back to localities/i }))
+
+    expect(await screen.findByText(/unsaved changes/i)).toBeTruthy()
+
+    await user.click(screen.getByRole('button', { name: /leave page/i }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('location').textContent).toBe('/locality')
+    })
+  })
+
+  it('allows navigation without prompting when the form is clean', async () => {
+    const user = userEvent.setup()
+    renderWithRouter()
+
+    await user.click(screen.getByRole('button', { name: /back to localities/i }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('location').textContent).toBe('/locality')
+    })
+    expect(screen.queryByText(/unsaved changes/i)).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- add a reusable UnsavedChangesProvider and hook to prompt before navigating away with dirty forms
- introduce a Locality form plus create and edit pages that tie into the new unsaved-changes flow
- cover locality navigation blockers with new RTL tests for dirty and clean form scenarios

## Testing
- npm run lint:frontend
- npm run tsc:frontend

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694297a480748329b4d358226f7d5f1f)