### PR TITLE
[codex] Expand EditRestricted write access

### DIFF
--- a/backend/src/api-tests/locality/create.test.ts
+++ b/backend/src/api-tests/locality/create.test.ts
@@ -65,18 +65,32 @@ describe('Creating new locality works', () => {
     expect(created!.synonyms).toEqual(expect.arrayContaining(['Shuijiazui', 'Bahe']))
   })
 
-  it('Creation fails without permissions', async () => {
+  it('Creation fails without permissions for unauthenticated users', async () => {
     logout()
     const resultNoPerm = await send('locality', 'PUT', {
       locality: { ...newLocalityBasis },
     })
     expect(resultNoPerm.body).toEqual(noPermError)
     expect(resultNoPerm.status).toEqual(403)
+  })
 
+  it('Creation succeeds for EditRestricted users within their projects', async () => {
     logout()
     await login('testEr', 'test')
     const resultEr = await send('locality', 'PUT', {
       locality: { ...newLocalityBasis },
+    })
+    expect(resultEr.status).toEqual(200)
+  })
+
+  it('Creation fails for EditRestricted users outside their projects', async () => {
+    logout()
+    await login('testEr', 'test')
+    const resultEr = await send('locality', 'PUT', {
+      locality: {
+        ...newLocalityBasis,
+        now_plr: [{ pid: 35, rowState: 'new' }],
+      },
     })
     expect(resultEr.body).toEqual(noPermError)
     expect(resultEr.status).toEqual(403)

--- a/backend/src/api-tests/museum/create.test.ts
+++ b/backend/src/api-tests/museum/create.test.ts
@@ -71,17 +71,17 @@ describe('Creating new museum works', () => {
     expect(resultStatusNoPerm).toEqual(403)
 
     await login('testEr')
-    const { body: resultBodyEr, status: resultStatusEr } = await send('museum/', 'PUT', {
-      museum: { ...newMuseumBasis, museum: 'New Museum 3' },
+    const { body: resultBodyEr, status: resultStatusEr } = await send<{ museum: string }>('museum/', 'PUT', {
+      museum: { ...newMuseumBasis, museum: 'NM3' },
     })
-    expect(resultBodyEr).toEqual(noPermError)
-    expect(resultStatusEr).toEqual(403)
+    expect(resultStatusEr).toEqual(200)
+    expect(typeof resultBodyEr.museum).toEqual('string')
 
     await login('testEu')
-    const { body: resultBodyEu, status: resultStatusEu } = await send('museum/', 'PUT', {
-      museum: { ...newMuseumBasis, museum: 'New Museum 4' },
+    const { body: resultBodyEu, status: resultStatusEu } = await send<{ museum: string }>('museum/', 'PUT', {
+      museum: { ...newMuseumBasis, museum: 'NM4' },
     })
-    expect(resultBodyEu).toEqual(noPermError)
-    expect(resultStatusEu).toEqual(403)
+    expect(resultStatusEu).toEqual(200)
+    expect(typeof resultBodyEu.museum).toEqual('string')
   })
 })

--- a/backend/src/api-tests/museum/update.test.ts
+++ b/backend/src/api-tests/museum/update.test.ts
@@ -56,17 +56,17 @@ describe('Updating museum works', () => {
     expect(resultStatusNoPerm).toEqual(403)
 
     await login('testEr')
-    const { body: resultBodyEr, status: resultStatusEr } = await send('museum/', 'PUT', {
+    const { body: resultBodyEr, status: resultStatusEr } = await send<{ museum: string }>('museum/', 'PUT', {
       museum: { ...editedMuseum, institution: 'New Museum 2' },
     })
-    expect(resultBodyEr).toEqual(noPermError)
-    expect(resultStatusEr).toEqual(403)
+    expect(resultStatusEr).toEqual(200)
+    expect(typeof resultBodyEr.museum).toEqual('string')
 
     await login('testEu')
-    const { body: resultBodyEu, status: resultStatusEu } = await send('museum/', 'PUT', {
+    const { body: resultBodyEu, status: resultStatusEu } = await send<{ museum: string }>('museum/', 'PUT', {
       museum: { ...editedMuseum, institution: 'New Museum 2' },
     })
-    expect(resultBodyEu).toEqual(noPermError)
-    expect(resultStatusEu).toEqual(403)
+    expect(resultStatusEu).toEqual(200)
+    expect(typeof resultBodyEu.museum).toEqual('string')
   })
 })

--- a/backend/src/api-tests/reference/create.test.ts
+++ b/backend/src/api-tests/reference/create.test.ts
@@ -182,10 +182,10 @@ describe('Creating new reference works', () => {
     expect(resultStatusNoPerm).toEqual(403)
 
     await login('testEr')
-    const { body: resultBodyEr, status: resultStatusEr } = await send('reference/', 'PUT', {
+    const { body: resultBodyEr, status: resultStatusEr } = await send<{ rid: number }>('reference/', 'PUT', {
       reference: { ...newReferenceBasis },
     })
-    expect(resultBodyEr).toEqual(noPermError)
-    expect(resultStatusEr).toEqual(403)
+    expect(resultStatusEr).toEqual(200)
+    expect(typeof resultBodyEr.rid).toEqual('number')
   })
 })

--- a/backend/src/api-tests/species/create.test.ts
+++ b/backend/src/api-tests/species/create.test.ts
@@ -15,7 +15,7 @@ describe('Creating new species works', () => {
     await resetDatabase()
     await login()
     createdSpecies = null
-  })
+  }, resetDatabaseTimeout)
   afterAll(async () => {
     await pool.end()
   })
@@ -83,20 +83,21 @@ describe('Creating new species works', () => {
     expect(resultWithRef.status).toEqual(200)
   })
 
-  it('Creation fails without permissions for non-authenticated and non-privileged users', async () => {
+  it('Creation fails without permissions for non-authenticated users', async () => {
     logout()
     const result1 = await send('species', 'PUT', {
       species: { ...newSpeciesBasis, comment: 'species test' },
     })
     expect(result1.body).toEqual(noPermError)
     expect(result1.status).toEqual(403)
+  })
 
+  it('Creation succeeds for EditRestricted users', async () => {
     logout()
     await login('testEr', 'test')
     const result2 = await send('species', 'PUT', {
       species: { ...newSpeciesBasis, comment: 'species test' },
     })
-    expect(result2.body).toEqual(noPermError)
-    expect(result2.status).toEqual(403)
+    expect(result2.status).toEqual(200)
   })
 })

--- a/backend/src/routes/locality.ts
+++ b/backend/src/routes/locality.ts
@@ -1,13 +1,14 @@
 import { Request, Router } from 'express'
 import {
   getAllLocalities,
+  canEditRestrictedWriteLocality,
   getLocalityDetails,
   normalizeLocalityAges,
   validateEntireLocality,
 } from '../services/locality'
 import { fixBigInt } from '../utils/common'
 import { EditDataType, EditMetaData, LocalityDetailsType, Role } from '../../../frontend/src/shared/types'
-import { requireOneOf } from '../middlewares/authorizer'
+import { AccessError, requireOneOf } from '../middlewares/authorizer'
 import { deleteLocality, writeLocality } from '../services/write/locality'
 
 const router = Router()
@@ -26,9 +27,13 @@ router.get('/:id', async (req, res) => {
 
 router.put(
   '/',
-  requireOneOf([Role.Admin, Role.EditUnrestricted]),
+  requireOneOf([Role.Admin, Role.EditUnrestricted, Role.EditRestricted]),
   async (req: Request<object, object, { locality: EditDataType<LocalityDetailsType> & EditMetaData }>, res) => {
     const { comment, references, ...editedLocality } = req.body.locality
+    if (req.user?.role === Role.EditRestricted) {
+      const hasAccess = await canEditRestrictedWriteLocality(editedLocality, req.user)
+      if (!hasAccess) throw new AccessError()
+    }
     const normalizedLocality = normalizeLocalityAges(editedLocality)
     const validationErrors = await validateEntireLocality({ ...normalizedLocality, references: references })
     if (validationErrors.length > 0) {

--- a/backend/src/routes/museum.ts
+++ b/backend/src/routes/museum.ts
@@ -32,7 +32,7 @@ router.get('/:id', async (req, res) => {
 
 router.put(
   '/',
-  requireOneOf([Role.Admin]),
+  requireOneOf([Role.Admin, Role.EditUnrestricted, Role.EditRestricted]),
   async (req: Request<object, object, { museum: EditDataType<Museum> & EditMetaData }>, res) => {
     try {
       const { ...editedMuseum } = req.body.museum

--- a/backend/src/routes/project.ts
+++ b/backend/src/routes/project.ts
@@ -5,8 +5,8 @@ import { Role } from '../../../frontend/src/shared/types'
 
 const router = Router()
 
-router.get('/all', async (_req, res) => {
-  const projects = await getAllProjects()
+router.get('/all', async (req, res) => {
+  const projects = await getAllProjects(req.user)
   return res.status(200).send(projects)
 })
 

--- a/backend/src/routes/reference.ts
+++ b/backend/src/routes/reference.ts
@@ -100,7 +100,7 @@ router.get('/species/:id', async (req, res) => {
 
 router.put(
   '/',
-  requireOneOf([Role.Admin, Role.EditUnrestricted]),
+  requireOneOf([Role.Admin, Role.EditUnrestricted, Role.EditRestricted]),
   async (req: Request<object, object, { reference: EditDataType<ReferenceDetailsType> & EditMetaData }>, res) => {
     const { ...editedReference } = req.body.reference
     const referenceTypes = await getReferenceTypes()

--- a/backend/src/routes/species.ts
+++ b/backend/src/routes/species.ts
@@ -26,7 +26,7 @@ router.get('/:id', async (req, res) => {
 
 router.put(
   '/',
-  requireOneOf([Role.Admin, Role.EditUnrestricted]),
+  requireOneOf([Role.Admin, Role.EditUnrestricted, Role.EditRestricted]),
   async (req: Request<object, object, { species: SpeciesDetailsType & EditMetaData }>, res) => {
     const { comment, references, ...editedSpecies } = req.body.species
     const validationErrors = await validateEntireSpecies({ ...editedSpecies, references })

--- a/backend/src/routes/user.ts
+++ b/backend/src/routes/user.ts
@@ -58,13 +58,26 @@ router.post('/login', async (req, res) => {
     where: { user_id: foundUser.user_id },
     select: {
       initials: true,
-      now_proj: { select: { now_plr: { select: { now_loc: { select: { lid: true } } } } } },
     },
   })
 
   if (!personResult) throw new Error('User found but not person; this should not happen.')
 
-  const associatedLocalityIds = personResult.now_proj.flatMap(proj => proj.now_plr.map(plr => plr.now_loc.lid))
+  const projectLinks = await nowDb.now_proj_people.findMany({
+    where: { initials: personResult.initials },
+    select: { pid: true },
+  })
+
+  const projectIds = Array.from(new Set(projectLinks.map(link => link.pid)))
+
+  const localityLinks = projectIds.length
+    ? await nowDb.now_plr.findMany({
+        where: { pid: { in: projectIds } },
+        select: { lid: true },
+      })
+    : []
+
+  const associatedLocalityIds = Array.from(new Set(localityLinks.map(link => link.lid)))
 
   await nowDb.com_users.update({ where: { user_id: foundUser.user_id }, data: { last_login: new Date() } })
 

--- a/backend/src/services/locality.ts
+++ b/backend/src/services/locality.ts
@@ -47,13 +47,43 @@ export const normalizeLocalityAges = (locality: EditDataType<LocalityDetailsType
   frac_min: normalizeFraction(locality.frac_min) as EditDataType<LocalityDetailsType>['frac_min'],
 })
 
-const getIdsOfUsersProjects = async (user: User) => {
+export const getIdsOfUsersProjects = async (user: User) => {
   const usersProjects = await nowDb.now_proj_people.findMany({
     where: { initials: user.initials },
     select: { pid: true },
   })
 
   return new Set(usersProjects.map(({ pid }) => pid))
+}
+
+const getActiveProjectIds = (locality: EditDataType<LocalityDetailsType>) => {
+  if (!locality.now_plr) return [] as number[]
+  return locality.now_plr
+    .filter(link => link.rowState !== 'removed')
+    .map(link => link.pid ?? link.now_proj?.pid)
+    .flatMap(pid => {
+      if (typeof pid === 'string') {
+        const parsed = parseInt(pid, 10)
+        return Number.isFinite(parsed) ? [parsed] : []
+      }
+      if (typeof pid === 'number' && Number.isFinite(pid)) return [pid]
+      return []
+    })
+}
+
+export const canEditRestrictedWriteLocality = async (locality: EditDataType<LocalityDetailsType>, user: User) => {
+  const userProjectIds = await getIdsOfUsersProjects(user)
+  let activeProjectIds = getActiveProjectIds(locality)
+
+  if (activeProjectIds.length === 0 && locality.lid) {
+    const existingLocality = await getLocalityDetails(locality.lid, user)
+    if (existingLocality) {
+      activeProjectIds = existingLocality.now_plr.map(link => link.pid)
+    }
+  }
+
+  if (activeProjectIds.length === 0) return false
+  return activeProjectIds.every(pid => userProjectIds.has(pid))
 }
 
 type LocalityPreFilter = {

--- a/backend/src/services/project.ts
+++ b/backend/src/services/project.ts
@@ -1,6 +1,19 @@
+import { Role, User } from '../../../frontend/src/shared/types'
 import { nowDb } from '../utils/db'
 
-export const getAllProjects = async () => {
+export const getAllProjects = async (user?: User) => {
+  if (user?.role === Role.EditRestricted) {
+    const projectLinks = await nowDb.now_proj_people.findMany({
+      where: { initials: user.initials },
+      select: { pid: true },
+    })
+    const projectIds = Array.from(new Set(projectLinks.map(link => link.pid)))
+    if (projectIds.length === 0) return []
+    return nowDb.now_proj.findMany({
+      where: { pid: { in: projectIds } },
+    })
+  }
+
   const result = await nowDb.now_proj.findMany({})
   return result
 }

--- a/backend/src/utils/db.ts
+++ b/backend/src/utils/db.ts
@@ -3,7 +3,7 @@ import { logger } from './logger'
 import { PrismaClient as NowClient } from '../../prisma/generated/now_test_client'
 import { PrismaClient as LogClient } from '../../prisma/generated/now_log_test_client/default'
 import mariadb from 'mariadb'
-import { MARIADB_HOST, MARIADB_PASSWORD, DB_CONNECTION_LIMIT, MARIADB_USER, RUNNING_ENV } from './config'
+import { MARIADB_HOST, MARIADB_PASSWORD, DB_CONNECTION_LIMIT, MARIADB_USER, RUNNING_ENV, LOG_DB_NAME } from './config'
 
 import { readFile } from 'fs/promises'
 import { PathLike } from 'fs'
@@ -16,8 +16,8 @@ type LogRecord = Record<string, unknown> & {
 }
 
 type LogModel = {
-  findMany: (...args: unknown[]) => Promise<LogRecord[]>
-  findFirst: (...args: unknown[]) => Promise<LogRecord | null>
+  findMany: (args?: { where?: Record<string, unknown> }) => Promise<LogRecord[]>
+  findFirst: (args?: { where?: Record<string, unknown> }) => Promise<LogRecord | null>
   fields: Record<string, unknown>
 }
 
@@ -25,6 +25,113 @@ type LogPrismaClient = LogClient & { log: LogModel }
 
 export const logDb = new LogClient() as unknown as LogPrismaClient
 export const nowDb = new NowClient()
+
+const fallbackLogFields = {
+  log_id: true,
+  event_time: true,
+  user_name: true,
+  server_name: true,
+  table_name: true,
+  pk_data: true,
+  column_name: true,
+  log_action: true,
+  old_data: true,
+  new_data: true,
+  luid: true,
+  suid: true,
+  tuid: true,
+  buid: true,
+} as const
+
+const buildLogWhere = (where?: Record<string, unknown>) => {
+  if (!where) return { sql: '', params: [] as unknown[] }
+
+  const clauses: string[] = []
+  const params: unknown[] = []
+
+  const pushInClause = (field: string, values: unknown[] | undefined) => {
+    if (!values || values.length === 0) {
+      clauses.push('1=0')
+      return
+    }
+    const placeholders = values.map(() => '?').join(', ')
+    clauses.push(`${field} IN (${placeholders})`)
+    params.push(...values)
+  }
+
+  if (typeof where.table_name === 'string') {
+    clauses.push('table_name = ?')
+    params.push(where.table_name)
+  }
+
+  const pkData = where.pk_data as { contains?: string } | undefined
+  if (pkData?.contains) {
+    clauses.push('pk_data LIKE ?')
+    params.push(`%${pkData.contains}%`)
+  }
+
+  if (Object.prototype.hasOwnProperty.call(where, 'luid')) {
+    const luid = where.luid as { in?: number[] } | undefined
+    pushInClause('luid', luid?.in)
+  }
+
+  if (Object.prototype.hasOwnProperty.call(where, 'suid')) {
+    const suid = where.suid as { in?: number[] } | undefined
+    pushInClause('suid', suid?.in)
+  }
+
+  if (Object.prototype.hasOwnProperty.call(where, 'tuid')) {
+    const tuid = where.tuid as { in?: number[] } | undefined
+    pushInClause('tuid', tuid?.in)
+  }
+
+  if (Object.prototype.hasOwnProperty.call(where, 'buid')) {
+    const buid = where.buid as { in?: number[] } | undefined
+    pushInClause('buid', buid?.in)
+  }
+
+  if (clauses.length === 0) return { sql: '', params }
+  return { sql: ` WHERE ${clauses.join(' AND ')}`, params }
+}
+
+const runLogQuery = async (sql: string, params: unknown[]): Promise<LogRecord[]> => {
+  const result = await (pool as { query: (sql: string, params?: unknown[]) => Promise<unknown> }).query(sql, params)
+  if (!Array.isArray(result)) return []
+  return result.filter((row): row is LogRecord => typeof row === 'object' && row !== null)
+}
+
+const getExistingLogModel = () => {
+  const candidate = (logDb as { log?: LogModel }).log
+  if (!candidate) return null
+  if (typeof candidate.findMany !== 'function') return null
+  if (!candidate.fields) return null
+  return candidate
+}
+
+const createFallbackLogModel = (): LogModel => {
+  const findMany = async ({ where }: { where?: Record<string, unknown> } = {}) => {
+    const { sql, params } = buildLogWhere(where)
+    return runLogQuery(`SELECT * FROM ${LOG_DB_NAME}.log${sql}`, params)
+  }
+
+  const findFirst = async ({ where }: { where?: Record<string, unknown> } = {}) => {
+    const rows = await findMany({ where })
+    return rows[0] ?? null
+  }
+
+  return {
+    fields: fallbackLogFields,
+    findMany,
+    findFirst,
+  }
+}
+
+const ensureLogClient = () => {
+  if (getExistingLogModel()) return
+  ;(logDb as { log: LogModel }).log = createFallbackLogModel()
+}
+
+ensureLogClient()
 
 export const getCrossSearchFields = () => {
   const nowLsKeys = Object.keys(

--- a/documentation/user_rights.md
+++ b/documentation/user_rights.md
@@ -30,6 +30,7 @@ The **EditRestricted** role is enforced in the backend for specific write operat
 - Deleting a locality requires the **Admin** or **EditUnrestricted** roles.
 
 NOTE: Users with the **EditRestricted** role can only create or update localities that belong to the same project as the user. Otherwise, they have reading rights only.
+When creating a new locality, EditRestricted users can only select projects where they are a member.
 
 ## Species
 

--- a/documentation/user_rights.md
+++ b/documentation/user_rights.md
@@ -20,7 +20,7 @@ In the new UI platform, there are 4 user roles:
 Users who have not logged in have the **ReadOnly** role.
 
 The Project, ProjectPrivate, and NowOffice roles exist in the old code but are currently not used. They don't exist at all in the frontend, and in the backend they are only used when assigning roles to test users.
-The **EditRestricted** role is also only used in the frontend to show/hide editing buttons, the backend does not use the role in any way.
+The **EditRestricted** role is enforced in the backend for specific write operations (for example, locality writes are limited to the user's projects).
 
 ## Locality
 
@@ -29,10 +29,7 @@ The **EditRestricted** role is also only used in the frontend to show/hide editi
 - Creating or updating a locality requires the **Admin**, **EditUnrestricted**, or **EditRestricted** roles.
 - Deleting a locality requires the **Admin** or **EditUnrestricted** roles.
 
-NOTE: Users with the **EditRestricted** role should only be able to create or update localities which are in the same project as the user. Otherwise, they have reading rights only.
-
-Current behaviour:
-- Users with the **EditRestricted** role can access the edit view in **their own** localities, but sending the PUT request to the backend fails because the role doesn't have permissions.
+NOTE: Users with the **EditRestricted** role can only create or update localities that belong to the same project as the user. Otherwise, they have reading rights only.
 
 ## Species
 
@@ -41,10 +38,6 @@ Current behaviour:
 - Creating or updating a species (and synonyms) requires the **Admin**, **EditUnrestricted**, or **EditRestricted** roles.
 - Deleting a species requires the **Admin** or **EditUnrestricted** roles.
 - Deleting a species synonym requires the **Admin**, **EditUnrestricted**, or **EditRestricted** roles.
-
-Current behaviour:
-
-- Users with the **EditRestricted** role can access the editing/creating new species view from the frontend, but sending the PUT request to the backend fails because the role doesn't have permissions.
 
 ## References
 
@@ -108,7 +101,7 @@ Current behaviour:
 | ---------------- | -------- | ------- | ---------- | ---------- | ----------- | ------- | ------- | -------- | ------- | ---------------------- | ------------- |
 | Admin            | ALL      | ALL     | ALL        | ALL        | ALL         | ALL     | ALL     | ALL      | ALL     | ALL                    | C             |
 | EditUnRestricted | ALL      | ALL     | ALL        | ALL        | ALL         | X       | X\*\*\* | R\*\*    | ALL     | ALL                    | C             |
-| EditRestricted   | CRU      | CRU     | CRU        | R          | R           | X       | X\*\*\* | R\*\*    | R       | R                      | C             |
+| EditRestricted   | CRU      | CRU     | CRU        | R          | R           | X       | X\*\*\* | R\*\*    | CRU     | R                      | C             |
 | ReadOnly         | R        | R       | R          | R          | R           | X       | X\*\*\* | R\*\*    | R       | R                      | C             |
 
 C = Create

--- a/documentation/user_rights.md
+++ b/documentation/user_rights.md
@@ -31,6 +31,7 @@ The **EditRestricted** role is enforced in the backend for specific write operat
 
 NOTE: Users with the **EditRestricted** role can only create or update localities that belong to the same project as the user. Otherwise, they have reading rights only.
 When creating a new locality, EditRestricted users can only select projects where they are a member.
+Users with the **EditUnrestricted** role are not limited by project membership when creating or updating localities.
 
 ## Species
 
@@ -101,7 +102,7 @@ When creating a new locality, EditRestricted users can only select projects wher
 | User group       | Locality | Species | References | Time Units | Time Bounds | Regions | Persons | Projects | Museums | Sedimentary Structures | Sending Email |
 | ---------------- | -------- | ------- | ---------- | ---------- | ----------- | ------- | ------- | -------- | ------- | ---------------------- | ------------- |
 | Admin            | ALL      | ALL     | ALL        | ALL        | ALL         | ALL     | ALL     | ALL      | ALL     | ALL                    | C             |
-| EditUnRestricted | ALL      | ALL     | ALL        | ALL        | ALL         | X       | X\*\*\* | R\*\*    | ALL     | ALL                    | C             |
+| EditUnrestricted | ALL      | ALL     | ALL        | ALL        | ALL         | X       | X\*\*\* | R\*\*    | ALL     | ALL                    | C             |
 | EditRestricted   | CRU      | CRU     | CRU        | R          | R           | X       | X\*\*\* | R\*\*    | CRU     | R                      | C             |
 | ReadOnly         | R        | R       | R          | R          | R           | X       | X\*\*\* | R\*\*    | R       | R                      | C             |
 

--- a/frontend/src/components/DetailView/DetailView.tsx
+++ b/frontend/src/components/DetailView/DetailView.tsx
@@ -260,7 +260,7 @@ export const DetailView = <T extends object>({
                 Delete
               </Button>
             )}
-            {!mode.read && Object.keys(fieldsWithErrors).length > 0 && <ErrorBox />}
+            {!mode.read && <ErrorBox />}
             {(!mode.read || initialState.mode.new) && onWrite && (
               <WriteButton onWrite={onWrite} taxonomy={taxonomy} hasStagingMode={hasStagingMode} />
             )}

--- a/frontend/src/components/DetailView/components.tsx
+++ b/frontend/src/components/DetailView/components.tsx
@@ -317,6 +317,7 @@ export const ErrorBox = <T,>() => {
     })
 
   const totalFields = fields.length + (hasMissingProject ? 1 : 0)
+  if (totalFields === 0) return null
   const title = totalFields > 1 ? `${totalFields} invalid fields` : '1 invalid field'
 
   return (

--- a/frontend/src/components/DetailView/components.tsx
+++ b/frontend/src/components/DetailView/components.tsx
@@ -1,13 +1,14 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import { Button, Box, Typography, CircularProgress, Divider, alpha, List, ListItemText, Tooltip } from '@mui/material'
 import { useDetailContext } from './Context/DetailContext'
-import { EditDataType, Editable, Reference, Species } from '@/shared/types'
+import { EditDataType, Editable, Reference, Role, Species } from '@/shared/types'
 import { useState, useEffect, Fragment } from 'react'
 import SaveIcon from '@mui/icons-material/Save'
 import { referenceValidator } from '@/shared/validators/validator'
 import { checkSpeciesTaxonomy, convertSpeciesTaxonomyFields, hasTaxonomyChanges } from '../../util/taxonomyUtilities'
 import { useGetAllSpeciesQuery, useGetAllSynonymsQuery } from '@/redux/speciesReducer'
 import { useNotify } from '@/hooks/notification'
+import { useUser } from '@/hooks/user'
 import { countryBoundingBoxes } from '@/country_data/countryBoundingBoxes'
 import { boundingBoxSplit, isPointInBoxes } from '@/util/isPointInBox'
 import { OutOfBoundsWarningModal, OutOfBoundsWarningModalState } from './OutOfBoundsWarningModal'
@@ -26,6 +27,7 @@ export const WriteButton = <T,>({
 }) => {
   const { data, editData, setEditData, mode, setMode, validator, fieldsWithErrors, setFieldsWithErrors, isDirty } =
     useDetailContext<T>()
+  const user = useUser()
   const [loading, setLoading] = useState(false)
   const { notify } = useNotify()
   const { data: speciesData } = useGetAllSpeciesQuery(!taxonomy ? skipToken : undefined)
@@ -54,6 +56,31 @@ export const WriteButton = <T,>({
     if (taxonomy && (!speciesData || !synonymData)) setLoading(true)
     else setLoading(false)
   }, [speciesData, synonymData])
+
+  const shouldHideWriteButton = (() => {
+    if (!mode.new || user.role !== Role.EditRestricted) return false
+    if (typeof editData !== 'object' || editData === null || !('now_plr' in editData)) return false
+
+    const links =
+      (
+        editData as {
+          now_plr?: Array<{
+            pid?: number | null
+            now_proj?: { pid?: number | null } | null
+            rowState?: string | null
+          }>
+        }
+      ).now_plr ?? []
+
+    const hasActiveProject = links.some(link => {
+      if (link.rowState === 'removed') return false
+      if (typeof link.pid === 'number' && Number.isFinite(link.pid)) return true
+      const nestedPid = link.now_proj?.pid
+      return typeof nestedPid === 'number' && Number.isFinite(nestedPid)
+    })
+
+    return !hasActiveProject
+  })()
 
   /*  validates all fields when entering new/editing mode
       to disable write button when unvisited tabs have
@@ -190,68 +217,74 @@ export const WriteButton = <T,>({
 
   return (
     <>
-      <OutOfBoundsWarningModal
-        isOpen={warningModalOpen}
-        onAnswer={isOkay => {
-          setWarningModalOpen(false)
-          if (isOkay) void handleWriteButtonClick()
-        }}
-        state={warningModalState}
-      />
-      <Tooltip
-        disableHoverListener={Object.keys(fieldsWithErrors).length === 0 && isDirty}
-        disableFocusListener={Object.keys(fieldsWithErrors).length === 0 && isDirty}
-        title={
-          Object.keys(fieldsWithErrors).length > 0
-            ? 'Resolve validation errors before saving.'
-            : isDirty
-              ? ''
-              : 'Make changes before finalizing the entry.'
-        }
-      >
-        <span>
-          <Button
-            disabled={Object.keys(fieldsWithErrors).length > 0 || !isDirty}
-            id="write-button"
-            sx={{ width: '20em' }}
-            onClick={() => {
-              // Check for out-of-boundness before saving
-
-              if (
-                !('dec_lat' in (editData as object)) ||
-                !('dec_long' in (editData as object)) ||
-                !('country' in (editData as object))
-              ) {
-                void handleWriteButtonClick()
-                return
-              }
-
-              const localityObject = editData as unknown as { dec_lat: number; dec_long: number; country: string }
-              if (!isCoordinateOutOfBounds(localityObject.dec_lat, localityObject.dec_long, localityObject.country)) {
-                void handleWriteButtonClick()
-                return
-              }
-
-              setWarningModalOpen(true)
-              setWarningModalState({
-                decLat: localityObject.dec_lat,
-                decLong: localityObject.dec_long,
-                // Guaranteed to exist by the isCoordinateOutOfBounds check above,
-                // as it will return false and return on no key found
-                boxes: boundingBoxSplit(countryBoundingBoxes[localityObject.country]),
-              })
+      {shouldHideWriteButton ? null : (
+        <>
+          <OutOfBoundsWarningModal
+            isOpen={warningModalOpen}
+            onAnswer={isOkay => {
+              setWarningModalOpen(false)
+              if (isOkay) void handleWriteButtonClick()
             }}
-            variant="contained"
+            state={warningModalState}
+          />
+          <Tooltip
+            disableHoverListener={Object.keys(fieldsWithErrors).length === 0 && isDirty}
+            disableFocusListener={Object.keys(fieldsWithErrors).length === 0 && isDirty}
+            title={
+              Object.keys(fieldsWithErrors).length > 0
+                ? 'Resolve validation errors before saving.'
+                : isDirty
+                  ? ''
+                  : 'Make changes before finalizing the entry.'
+            }
           >
-            {loading ? (
-              <CircularProgress size="1.2em" sx={{ color: 'white', marginRight: '1em' }} />
-            ) : (
-              <SaveIcon style={{ marginRight: '0.5em' }} />
-            )}
-            {getButtonText()}
-          </Button>
-        </span>
-      </Tooltip>
+            <span>
+              <Button
+                disabled={Object.keys(fieldsWithErrors).length > 0 || !isDirty}
+                id="write-button"
+                sx={{ width: '20em' }}
+                onClick={() => {
+                  // Check for out-of-boundness before saving
+
+                  if (
+                    !('dec_lat' in (editData as object)) ||
+                    !('dec_long' in (editData as object)) ||
+                    !('country' in (editData as object))
+                  ) {
+                    void handleWriteButtonClick()
+                    return
+                  }
+
+                  const localityObject = editData as unknown as { dec_lat: number; dec_long: number; country: string }
+                  if (
+                    !isCoordinateOutOfBounds(localityObject.dec_lat, localityObject.dec_long, localityObject.country)
+                  ) {
+                    void handleWriteButtonClick()
+                    return
+                  }
+
+                  setWarningModalOpen(true)
+                  setWarningModalState({
+                    decLat: localityObject.dec_lat,
+                    decLong: localityObject.dec_long,
+                    // Guaranteed to exist by the isCoordinateOutOfBounds check above,
+                    // as it will return false and return on no key found
+                    boxes: boundingBoxSplit(countryBoundingBoxes[localityObject.country]),
+                  })
+                }}
+                variant="contained"
+              >
+                {loading ? (
+                  <CircularProgress size="1.2em" sx={{ color: 'white', marginRight: '1em' }} />
+                ) : (
+                  <SaveIcon style={{ marginRight: '0.5em' }} />
+                )}
+                {getButtonText()}
+              </Button>
+            </span>
+          </Tooltip>
+        </>
+      )}
     </>
   )
 }

--- a/frontend/src/components/DetailView/components.tsx
+++ b/frontend/src/components/DetailView/components.tsx
@@ -217,7 +217,11 @@ export const WriteButton = <T,>({
 
   return (
     <>
-      {shouldHideWriteButton ? null : (
+      {shouldHideWriteButton ? (
+        <Typography color="text.secondary" variant="body2">
+          Select at least one project in the Projects tab to finalize this locality.
+        </Typography>
+      ) : (
         <>
           <OutOfBoundsWarningModal
             isOpen={warningModalOpen}

--- a/frontend/src/components/DetailView/components.tsx
+++ b/frontend/src/components/DetailView/components.tsx
@@ -217,11 +217,7 @@ export const WriteButton = <T,>({
 
   return (
     <>
-      {shouldHideWriteButton ? (
-        <Typography color="text.secondary" variant="body2">
-          Select at least one project in the Projects tab to finalize this locality.
-        </Typography>
-      ) : (
+      {shouldHideWriteButton ? null : (
         <>
           <OutOfBoundsWarningModal
             isOpen={warningModalOpen}
@@ -294,10 +290,34 @@ export const WriteButton = <T,>({
 }
 
 export const ErrorBox = <T,>() => {
-  const { fieldsWithErrors } = useDetailContext<T>()
+  const { fieldsWithErrors, editData, mode } = useDetailContext<T>()
+  const user = useUser()
   const fields = Object.keys(fieldsWithErrors)
+  const hasMissingProject =
+    mode.new &&
+    user.role === Role.EditRestricted &&
+    typeof editData === 'object' &&
+    editData !== null &&
+    'now_plr' in editData &&
+    !(
+      (
+        editData as {
+          now_plr?: Array<{
+            pid?: number | null
+            now_proj?: { pid?: number | null } | null
+            rowState?: string | null
+          }>
+        }
+      ).now_plr ?? []
+    ).some(link => {
+      if (link.rowState === 'removed') return false
+      if (typeof link.pid === 'number' && Number.isFinite(link.pid)) return true
+      const nestedPid = link.now_proj?.pid
+      return typeof nestedPid === 'number' && Number.isFinite(nestedPid)
+    })
 
-  const title = fields.length > 1 ? `${fields.length} invalid fields` : '1 invalid field'
+  const totalFields = fields.length + (hasMissingProject ? 1 : 0)
+  const title = totalFields > 1 ? `${totalFields} invalid fields` : '1 invalid field'
 
   return (
     <Box
@@ -315,6 +335,12 @@ export const ErrorBox = <T,>() => {
         {title}
       </Typography>
       <List sx={{ maxHeight: '5em', maxWidth: '30em', padding: '0em 0.8em 0em 0.8em', overflow: 'auto' }}>
+        {hasMissingProject && (
+          <>
+            <Divider component="li" />
+            <ListItemText sx={{ color: 'text.secondary' }} primary="Project: This field is required" />
+          </>
+        )}
         {fields.map(field => (
           <Fragment key={field}>
             <Divider component="li" />

--- a/frontend/src/components/pages.tsx
+++ b/frontend/src/components/pages.tsx
@@ -39,6 +39,11 @@ import { OccurrenceDetails } from './Occurrence/OccurrenceDetails'
 const noRights: EditRights = {}
 const fullRights: EditRights = { new: true, edit: true, delete: true }
 const limitedRights: EditRights = { new: true, edit: true }
+const userHasLocalityAccess = (user: UserState, id: string | number) => {
+  const parsedId = typeof id === 'number' ? id : parseInt(id, 10)
+  if (!Number.isFinite(parsedId)) return false
+  return user.localities.includes(parsedId)
+}
 
 export const localityPage = (
   <UnsavedChangesProvider>
@@ -55,7 +60,7 @@ export const localityPage = (
         if ([Role.Admin, Role.EditUnrestricted].includes(user.role)) return fullRights
         if (user.role === Role.EditRestricted) {
           if (id === '' || id === 'new') return { new: true }
-          if (user.localities.includes(id as number)) return limitedRights
+          if (userHasLocalityAccess(user, id)) return limitedRights
         }
         return noRights
       }}
@@ -88,7 +93,7 @@ ${occurrence.max_age ?? ''} Ma (${occurrence.bfa_max ?? ''}) – ${occurrence.mi
     }
     getEditRights={(user: UserState, id: string | number) => {
       if ([Role.Admin, Role.EditUnrestricted].includes(user.role)) return fullRights
-      if (user.role === Role.EditRestricted && user.localities.includes(id as number)) return limitedRights
+      if (user.role === Role.EditRestricted && userHasLocalityAccess(user, id)) return limitedRights
       return noRights
     }}
   />

--- a/frontend/src/components/pages.tsx
+++ b/frontend/src/components/pages.tsx
@@ -53,7 +53,10 @@ export const localityPage = (
       }
       getEditRights={(user: UserState, id: string | number) => {
         if ([Role.Admin, Role.EditUnrestricted].includes(user.role)) return fullRights
-        if (user.role === Role.EditRestricted && user.localities.includes(id as number)) return limitedRights
+        if (user.role === Role.EditRestricted) {
+          if (id === '' || id === 'new') return { new: true }
+          if (user.localities.includes(id as number)) return limitedRights
+        }
         return noRights
       }}
     />

--- a/frontend/src/components/pages.tsx
+++ b/frontend/src/components/pages.tsx
@@ -124,9 +124,9 @@ export const museumPage = (
       idFieldName="museum"
       createTitle={(museum: Museum) => `${museum.institution}`}
       createSubtitle={(museum: Museum) => `${museum.city ? `${museum.city}, ` : ''}${museum.country}`}
-      getEditRights={(user: UserState, id: string | number) => {
+      getEditRights={(user: UserState) => {
         if ([Role.Admin, Role.EditUnrestricted].includes(user.role)) return fullRights
-        if (user.role === Role.EditRestricted && user.localities.includes(id as number)) return limitedRights
+        if (user.role === Role.EditRestricted) return limitedRights
         return noRights
       }}
     />
@@ -144,7 +144,7 @@ export const referencePage = (
       createSubtitle={createReferenceSubtitle}
       getEditRights={(user: UserState) => {
         if ([Role.Admin, Role.EditUnrestricted].includes(user.role)) return fullRights
-        if (user.role === Role.EditRestricted) return { new: true }
+        if (user.role === Role.EditRestricted) return limitedRights
         return noRights
       }}
     />

--- a/frontend/src/redux/localityReducer.ts
+++ b/frontend/src/redux/localityReducer.ts
@@ -1,4 +1,5 @@
 import { api } from './api'
+import { addLocality } from '@/redux/userReducer'
 import { EditDataType, Locality, LocalityDetailsType } from '@/shared/types'
 
 const sanitizeLocalityProjects = (locality?: EditDataType<LocalityDetailsType>) => {
@@ -33,7 +34,8 @@ const localitiesApi = api.injectEndpoints({
       async onQueryStarted(locality, { dispatch, queryFulfilled }) {
         if (!locality.lid) {
           try {
-            await queryFulfilled
+            const { data } = await queryFulfilled
+            dispatch(addLocality(data.id))
           } catch {
             // The component handles create errors; avoid leaking RTK Query rejections
             // as unhandled promise rejections during locality creation flows.

--- a/frontend/src/redux/userReducer.ts
+++ b/frontend/src/redux/userReducer.ts
@@ -76,6 +76,10 @@ const userSlice = createSlice({
     setToken(state, action: PayloadAction<string>) {
       return { ...state, token: action.payload }
     },
+    addLocality(state, action: PayloadAction<number>) {
+      if (state.localities.includes(action.payload)) return state
+      return { ...state, localities: [...state.localities, action.payload] }
+    },
     removeFirstLogin(state) {
       return { ...state, isFirstLogin: undefined }
     },
@@ -85,6 +89,6 @@ const userSlice = createSlice({
   },
 })
 
-export const { setUser, setToken, clearUser, removeFirstLogin } = userSlice.actions
+export const { setUser, setToken, addLocality, clearUser, removeFirstLogin } = userSlice.actions
 export const userReducer = userSlice.reducer
 export const { useTryLoginMutation, useChangePasswordMutation, useCreateUserMutation } = userApi

--- a/frontend/src/tests/components/SpeciesWriteButton.test.tsx
+++ b/frontend/src/tests/components/SpeciesWriteButton.test.tsx
@@ -2,10 +2,12 @@ import { describe, expect, it, jest, beforeEach } from '@jest/globals'
 import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { WriteButton } from '@/components/DetailView/components'
-import { EditDataType, Species } from '@/shared/types'
+import { EditDataType, Role, Species } from '@/shared/types'
 import { useDetailContext, type DetailContextType } from '@/components/DetailView/Context/DetailContext'
 import { useGetAllSpeciesQuery, useGetAllSynonymsQuery } from '@/redux/speciesReducer'
 import { checkSpeciesTaxonomy } from '@/util/taxonomyUtilities'
+import { useUser } from '@/hooks/user'
+import { UserState } from '@/redux/userReducer'
 
 const mockNotify = jest.fn()
 
@@ -15,6 +17,10 @@ jest.mock('@/components/DetailView/Context/DetailContext', () => ({
 
 jest.mock('@/hooks/notification', () => ({
   useNotify: () => ({ notify: mockNotify }),
+}))
+
+jest.mock('@/hooks/user', () => ({
+  useUser: jest.fn(),
 }))
 
 jest.mock('@/redux/speciesReducer', () => ({
@@ -35,6 +41,7 @@ const mockUseDetailContext = useDetailContext as jest.MockedFunction<() => Detai
 const mockUseGetAllSpeciesQuery = useGetAllSpeciesQuery as jest.MockedFunction<typeof useGetAllSpeciesQuery>
 const mockUseGetAllSynonymsQuery = useGetAllSynonymsQuery as jest.MockedFunction<typeof useGetAllSynonymsQuery>
 const mockCheckSpeciesTaxonomy = checkSpeciesTaxonomy as jest.MockedFunction<typeof checkSpeciesTaxonomy>
+const mockUseUser = useUser as jest.MockedFunction<typeof useUser>
 
 const modeEdit = { read: false, staging: false, new: false, option: 'edit' as const }
 const modeStagingEdit = { read: false, staging: true, new: false, option: 'staging-edit' as const }
@@ -125,6 +132,15 @@ const renderButton = (
 describe('WriteButton taxonomy handling', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    const mockUser: UserState = {
+      token: null,
+      username: 'tester',
+      role: Role.Admin,
+      initials: null,
+      localities: [],
+      isFirstLogin: undefined,
+    }
+    mockUseUser.mockReturnValue(mockUser)
   })
 
   it('skips duplicate taxonomy validation when taxonomy fields are unchanged', async () => {

--- a/test_data/sqlfiles/now_test.sql
+++ b/test_data/sqlfiles/now_test.sql
@@ -946,6 +946,7 @@ LOCK TABLES `now_proj_people` WRITE;
 /*!40000 ALTER TABLE `now_proj_people` DISABLE KEYS */;
 INSERT INTO `now_proj_people` VALUES
 (3,'ER'),
+(3,'TEST-ER'),
 (14,'ER'),
 (35,'TEST-PL'),
 (36,'TEST-PL');
@@ -2241,4 +2242,3 @@ INSERT INTO `ref_ref_type` VALUES
 (14,'Undefined');
 /*!40000 ALTER TABLE `ref_ref_type` ENABLE KEYS */;
 UNLOCK TABLES;
-


### PR DESCRIPTION
## Summary
- allow EditRestricted writes for locality (project-scoped), species, reference, and museum routes
- align frontend edit/create gating with backend permissions
- update API tests, seed data, and user-rights documentation
- add a fallback log client for log DB access in test environments

## Testing
- `npm run lint`
- `npm run tsc`
- `cd backend && npm run test:api:local -- --runTestsByPath src/api-tests/reference/create.test.ts src/api-tests/museum/create.test.ts src/api-tests/museum/update.test.ts`
- `cd backend && npm run test:api:local -- --runTestsByPath src/api-tests/locality/create.test.ts src/api-tests/species/create.test.ts` (ran earlier; not rerun after the latest local changes)
