### PR TITLE
[codex] Fix e2e helpers and tab indices

### DIFF
--- a/cypress/e2e/locality.cy.js
+++ b/cypress/e2e/locality.cy.js
@@ -479,7 +479,7 @@ describe('Editing a locality', () => {
   })
 
   it('adds collecting methods from the selector and persists them', () => {
-    cy.visit(`/locality/20920?tab=4`)
+    cy.visit(`/locality/20920?tab=5`)
     cy.contains('Lantian-Shuijiazui')
     cy.get('[id=edit-button]').click()
 
@@ -490,7 +490,7 @@ describe('Editing a locality', () => {
     cy.addReferenceAndSave()
     cy.contains('Edited item successfully.')
 
-    cy.visit(`/locality/20920?tab=4`)
+    cy.visit(`/locality/20920?tab=5`)
     cy.contains('wet_screen')
   })
 })
@@ -610,7 +610,7 @@ describe('Linking projects to an existing locality', () => {
 
   beforeEach('Login as admin and open projects tab', () => {
     cy.loginWithSession('testSu')
-    cy.visit(`/locality/${localityId}?tab=9`)
+    cy.visit(`/locality/${localityId}?tab=10`)
     cy.contains('Dmanisi')
   })
 

--- a/cypress/e2e/locality.cy.js
+++ b/cypress/e2e/locality.cy.js
@@ -625,7 +625,7 @@ describe('Linking projects to an existing locality', () => {
 
     cy.addReferenceAndSave()
     cy.contains('Edited item successfully.')
-    cy.visit(`/locality/${localityId}?tab=9`)
+    cy.visit(`/locality/${localityId}?tab=10`)
     cy.contains(newProjectCode)
 
     cy.get('[id=edit-button]').click()
@@ -633,7 +633,7 @@ describe('Linking projects to an existing locality', () => {
 
     cy.addReferenceAndSave()
     cy.contains('Edited item successfully.')
-    cy.visit(`/locality/${localityId}?tab=9`)
+    cy.visit(`/locality/${localityId}?tab=10`)
     cy.contains(newProjectCode).should('not.exist')
   })
 })

--- a/cypress/e2e/misc.cy.js
+++ b/cypress/e2e/misc.cy.js
@@ -33,7 +33,7 @@ before('Reset database', () => {
 
 describe('Test individual features across the app', () => {
   it('Locality update tab opens, detailed modal works, view-link works', () => {
-    cy.visit(`/locality/24750?tab=10`)
+    cy.visit(`/locality/24750?tab=11`)
     cy.contains('2006-10-16')
     cy.contains(
       'Cande (1992). A new geomagnetic polarity time scale for the Late Cretaceous and Cenozoic. Geology 97: 13917-13951.'

--- a/cypress/e2e/updateLogNavigation.cy.ts
+++ b/cypress/e2e/updateLogNavigation.cy.ts
@@ -25,7 +25,7 @@ describe('Update log navigation', () => {
   }
 
   it('returns to the update log after viewing a reference detail', () => {
-    cy.visit('/locality/21050?tab=10')
+    cy.visit('/locality/21050?tab=11')
     cy.contains('Updates')
 
     openFirstUpdateWithReference()

--- a/cypress/e2e/updateLogNavigation.cy.ts
+++ b/cypress/e2e/updateLogNavigation.cy.ts
@@ -38,7 +38,7 @@ describe('Update log navigation', () => {
     cy.contains('button', 'Return to table').should('be.visible').click()
 
     cy.url().should('include', '/locality/21050')
-    cy.url().should('include', 'tab=10')
+    cy.url().should('include', 'tab=11')
     cy.contains('Updates')
   })
 })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -29,9 +29,8 @@ Cypress.Commands.overwrite('visit', (originalFn, url, options) => {
   const resolvedUrl = targetUrl ? new URL(targetUrl, Cypress.config('baseUrl')).toString() : Cypress.config('baseUrl')
   const appWaitTimeoutMs = Number(Cypress.env('appWaitTimeoutMs') ?? 60000)
 
-  return cy
-    .task('waitForAppHealthy', { url: resolvedUrl }, { timeout: appWaitTimeoutMs })
-    .then(() => originalFn(url, options))
+  cy.task('waitForAppHealthy', { url: resolvedUrl }, { timeout: appWaitTimeoutMs })
+  return originalFn(url, options)
 })
 
 Cypress.Commands.add('login', username => {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -29,8 +29,9 @@ Cypress.Commands.overwrite('visit', (originalFn, url, options) => {
   const resolvedUrl = targetUrl ? new URL(targetUrl, Cypress.config('baseUrl')).toString() : Cypress.config('baseUrl')
   const appWaitTimeoutMs = Number(Cypress.env('appWaitTimeoutMs') ?? 60000)
 
-  cy.task('waitForAppHealthy', { url: resolvedUrl }, { timeout: appWaitTimeoutMs })
-  return originalFn(url, options)
+  return cy
+    .task('waitForAppHealthy', { url: resolvedUrl }, { timeout: appWaitTimeoutMs })
+    .then(() => originalFn(url, options))
 })
 
 Cypress.Commands.add('login', username => {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -31,7 +31,9 @@ Cypress.Commands.overwrite('visit', (originalFn, url, options) => {
 
   return cy
     .task('waitForAppHealthy', { url: resolvedUrl }, { timeout: appWaitTimeoutMs })
-    .then(() => originalFn(url, options))
+    .then(() => {
+      originalFn(url, options)
+    })
 })
 
 Cypress.Commands.add('login', username => {


### PR DESCRIPTION
## Summary
- fix Cypress `visit` override to avoid returning a hanging thenable
- update Locality tab indices used by E2E specs (Taphonomy, Projects, Updates)

## Why
- recent tab ordering changes caused selectors to point at the wrong tabs
- Cypress override returned a promise inside `cy.then`, leading to timeouts

## Impact
- stabilizes affected E2E specs without changing app behavior

## Root Cause
- tab index drift and a non-resolving thenable in the Cypress `visit` overwrite

## Testing
- `npm run lint` (via pre-commit)
- `npm run tsc` (via pre-commit)
- E2E run not executed here due to Cypress sandbox restrictions in this environment
