### PR TITLE
[codex] Prevent duplicate reference authors

### DIFF
--- a/cypress/e2e/reference.cy.js
+++ b/cypress/e2e/reference.cy.js
@@ -15,7 +15,9 @@ describe('Creating a journal', () => {
     cy.get('[id=title_primary-textfield]').type('New test reference')
 
     cy.contains('Select author').click()
-    cy.get('[data-cy=add-button-1]').click()
+    cy.get('.modal-content').within(() => {
+      cy.get('button[data-cy^="add-button"]').first().click()
+    })
     cy.contains('Close').click()
 
     cy.get('[id=date_primary-textfield]').type('2025')
@@ -38,7 +40,9 @@ describe('Creating a journal', () => {
     cy.get('[id=write-button]').should('be.disabled')
 
     cy.contains('Select author').click()
-    cy.get('[data-cy=add-button-1]').click()
+    cy.get('.modal-content').within(() => {
+      cy.get('button[data-cy^="add-button"]').first().click()
+    })
     cy.contains('Close').click()
     cy.contains('2 invalid fields')
     cy.get('[id=write-button]').should('be.disabled')
@@ -55,7 +59,9 @@ describe('Creating a journal', () => {
     cy.get('[data-testid=RemoveCircleOutlineIcon]').first().click() // removes the selected author
     cy.get('[id=write-button]').should('be.disabled')
     cy.contains('Select author').click()
-    cy.get('[data-cy=add-button-1]').click()
+    cy.get('.modal-content').within(() => {
+      cy.get('button[data-cy^="add-button"]').first().click()
+    })
     cy.contains('Close').click()
     cy.get('[id=write-button]').should('not.be.disabled')
   })
@@ -107,7 +113,9 @@ describe('Editing a journal', () => {
     cy.get('[id=title_primary-textfield]').type('New primary title.')
 
     cy.contains('Select author').click()
-    cy.get('[data-cy=add-button-2]').click()
+    cy.get('.modal-content').within(() => {
+      cy.get('button[data-cy^="add-button"]').first().click()
+    })
     cy.contains('Close').click()
 
     cy.get('[id=write-button]').click()
@@ -131,7 +139,9 @@ describe('Editing a journal', () => {
     cy.contains('1 invalid field')
     cy.get('[id=write-button]').should('be.disabled')
     cy.contains('Select author').click()
-    cy.get('[data-cy=add-button-1]').click()
+    cy.get('.modal-content').within(() => {
+      cy.get('button[data-cy^="add-button"]').first().click()
+    })
     cy.contains('Close').click()
     cy.get('[id=write-button]').should('not.be.disabled')
   })

--- a/frontend/src/components/Reference/Tabs/AuthorTab.tsx
+++ b/frontend/src/components/Reference/Tabs/AuthorTab.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useMemo } from 'react'
 import { ReferenceDetailsType, ReferenceAuthorType, RowState, EditDataType } from '@/shared/types'
 import { EditableTable } from '@/components/DetailView/common/EditableTable'
 import { EditingForm } from '@/components/DetailView/common/EditingForm'
@@ -14,6 +14,8 @@ interface AuthorTabProps {
   field_num_param: number
   tab_name?: string | null
 }
+
+type ReferenceAuthorSelectRow = ReferenceAuthorType & { authorKey: string }
 
 const tabNameToButtonText: { [tabName: string]: string } = {
   Authors: 'author',
@@ -35,6 +37,12 @@ function checkIndexes(editData: EditDataType<ReferenceDetailsType>): boolean {
     }
   }
   return needsUpdate
+}
+
+const buildAuthorKey = (author: Pick<ReferenceAuthorType, 'author_surname' | 'author_initials'>): string => {
+  const surname = author.author_surname?.trim().toLowerCase() ?? ''
+  const initials = author.author_initials?.trim().toLowerCase() ?? ''
+  return `${surname}|${initials}`
 }
 
 export const AuthorTab: React.FC<AuthorTabProps> = ({ field_num_param, tab_name = 'Authors' }) => {
@@ -59,7 +67,7 @@ export const AuthorTab: React.FC<AuthorTabProps> = ({ field_num_param, tab_name 
     return author.field_id?.toString() === field_num_param?.toString()
   })
 
-  const authorColumns: MRT_ColumnDef<ReferenceAuthorType>[] = [
+  const authorColumns: MRT_ColumnDef<ReferenceAuthorSelectRow>[] = [
     {
       accessorKey: 'author_initials',
       header: 'Author initials',
@@ -69,6 +77,18 @@ export const AuthorTab: React.FC<AuthorTabProps> = ({ field_num_param, tab_name 
       header: 'Surname',
     },
   ]
+
+  const selectedAuthorKeys = useMemo(() => {
+    return editData.ref_authors
+      .filter(author => author.field_id?.toString() === field_num_param?.toString())
+      .map(author => buildAuthorKey(author))
+  }, [editData.ref_authors, field_num_param])
+
+  const authorDataWithKey = useMemo<ReferenceAuthorSelectRow[]>(() => {
+    if (!authorData) return []
+    return authorData.map(author => ({ ...author, authorKey: buildAuthorKey(author) }))
+  }, [authorData])
+
   const formFields: { name: string; label: string; required?: boolean }[] = [
     { name: 'author_initials', label: 'Author initials', required: true },
     { name: 'author_surname', label: 'Surname', required: true },
@@ -121,19 +141,22 @@ export const AuthorTab: React.FC<AuthorTabProps> = ({ field_num_param, tab_name 
                 )
               }}
             />
-            <SelectingTable<ReferenceAuthorType, ReferenceDetailsType>
+            <SelectingTable<ReferenceAuthorSelectRow, ReferenceDetailsType>
               buttonText={`Select ${buttonText}`}
-              data={authorData}
+              data={authorDataWithKey}
               title="Authors"
               isError={isError}
               columns={authorColumns}
               fieldName="ref_authors"
-              idFieldName="data_id"
-              editingAction={(newAuthor: ReferenceAuthorType) => {
+              idFieldName="authorKey"
+              selectedValues={selectedAuthorKeys}
+              editingAction={(newAuthor: ReferenceAuthorSelectRow) => {
+                const { authorKey: _authorKey, ...author } = newAuthor
+                if (selectedAuthorKeys.includes(buildAuthorKey(author))) return
                 const updatedAuthors = [
                   ...editData.ref_authors,
                   {
-                    ...newAuthor,
+                    ...author,
                     rid: editData.rid,
                     au_num: editData.ref_authors.filter(author => author.field_id === field_num_param).length + 1,
                     field_id: field_num_param,

--- a/frontend/tests/components/ReferenceAuthorTab.test.tsx
+++ b/frontend/tests/components/ReferenceAuthorTab.test.tsx
@@ -1,0 +1,132 @@
+import { describe, expect, it, jest } from '@jest/globals'
+import { render, screen } from '@testing-library/react'
+
+import { AuthorTab } from '@/components/Reference/Tabs/AuthorTab'
+import type { DetailContextType } from '@/components/DetailView/Context/DetailContext'
+import { modeOptionToMode } from '@/components/DetailView/Context/DetailContext'
+import type { EditDataType, ReferenceAuthorType, ReferenceDetailsType } from '@/shared/types'
+
+jest.mock('@/components/DetailView/common/EditableTable', () => ({
+  EditableTable: () => <div data-testid="editable-table" />,
+}))
+
+jest.mock('@/components/DetailView/common/EditingForm', () => ({
+  EditingForm: () => <div data-testid="editing-form" />,
+}))
+
+jest.mock('@/components/DetailView/common/tabLayoutHelpers', () => ({
+  Grouped: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+const selectingTableMock = jest.fn()
+
+jest.mock('@/components/DetailView/common/SelectingTable', () => ({
+  SelectingTable: (props: {
+    data?: Array<{ author_surname?: string; author_initials?: string; authorKey?: string }>
+    selectedValues?: string[]
+    idFieldName: string
+  }) => {
+    selectingTableMock(props)
+    const { data = [], selectedValues = [], idFieldName } = props
+    const filtered = data.filter(row => !selectedValues.includes(String(row[idFieldName as keyof typeof row] ?? '')))
+    return <div data-testid="selecting-table">{filtered.map(row => row.author_surname).join(',')}</div>
+  },
+}))
+
+const mockUseGetReferenceAuthorsQuery = jest.fn()
+jest.mock('@/redux/referenceReducer', () => ({
+  useGetReferenceAuthorsQuery: (...args: unknown[]) => mockUseGetReferenceAuthorsQuery(...args),
+}))
+
+const mockUseDetailContext = jest.fn()
+jest.mock('@/components/DetailView/Context/DetailContext', () => ({
+  modeOptionToMode: {
+    edit: { read: false, staging: false, new: false, option: 'edit' },
+  },
+  useDetailContext: () => mockUseDetailContext(),
+}))
+
+const createDetailContextValue = (
+  overrides: Partial<DetailContextType<ReferenceDetailsType>> = {}
+): DetailContextType<ReferenceDetailsType> =>
+  ({
+    data: {} as ReferenceDetailsType,
+    mode: modeOptionToMode.edit,
+    setMode: () => {},
+    editData: { rid: 1, ref_authors: [] } as unknown as EditDataType<ReferenceDetailsType>,
+    setEditData: () => {},
+    textField: () => <></>,
+    bigTextField: () => <></>,
+    dropdown: () => <></>,
+    dropdownWithSearch: () => <></>,
+    radioSelection: () => <></>,
+    validator: () => ({ name: '', error: null }),
+    fieldsWithErrors: {},
+    setFieldsWithErrors: () => {},
+    isDirty: false,
+    resetEditData: () => {},
+    ...overrides,
+  }) as DetailContextType<ReferenceDetailsType>
+
+const buildAuthor = (overrides: Partial<ReferenceAuthorType> = {}): ReferenceAuthorType =>
+  ({
+    author_surname: 'Cande',
+    author_initials: 'S.C.',
+    ...overrides,
+  }) as ReferenceAuthorType
+
+describe('AuthorTab', () => {
+  it('filters out already-selected authors from the selector list', () => {
+    selectingTableMock.mockClear()
+    const existingAuthor = buildAuthor({ field_id: 2, au_num: 1 })
+    const otherAuthor = buildAuthor({ author_surname: 'Smith', author_initials: 'J.A.' })
+
+    mockUseDetailContext.mockReturnValue(
+      createDetailContextValue({
+        editData: { rid: 1, ref_authors: [existingAuthor] } as unknown as EditDataType<ReferenceDetailsType>,
+      })
+    )
+
+    mockUseGetReferenceAuthorsQuery.mockReturnValue({
+      data: [existingAuthor, otherAuthor],
+      isError: false,
+    })
+
+    render(<AuthorTab field_num_param={2} tab_name="Authors" />)
+
+    expect(selectingTableMock).toHaveBeenCalled()
+    const selectingProps = selectingTableMock.mock.calls[0][0] as {
+      data?: Array<{ authorKey?: string }>
+      selectedValues?: string[]
+    }
+    expect(selectingProps.selectedValues).toContain('cande|s.c.')
+    expect(selectingProps.data?.[0]?.authorKey).toBeDefined()
+
+    const renderedList = screen.getByTestId('selecting-table').textContent ?? ''
+    expect(renderedList).toContain('Smith')
+    expect(renderedList).not.toContain('Cande')
+  })
+
+  it('filters duplicates per author field grouping', () => {
+    selectingTableMock.mockClear()
+    const selectedEditor = buildAuthor({ author_surname: 'Brown', author_initials: 'T.', field_id: 12, au_num: 1 })
+    const otherEditor = buildAuthor({ author_surname: 'Ng', author_initials: 'Q.' })
+
+    mockUseDetailContext.mockReturnValue(
+      createDetailContextValue({
+        editData: { rid: 1, ref_authors: [selectedEditor] } as unknown as EditDataType<ReferenceDetailsType>,
+      })
+    )
+
+    mockUseGetReferenceAuthorsQuery.mockReturnValue({
+      data: [selectedEditor, otherEditor],
+      isError: false,
+    })
+
+    render(<AuthorTab field_num_param={12} tab_name="Editors" />)
+
+    const renderedList = screen.getByTestId('selecting-table').textContent ?? ''
+    expect(renderedList).toContain('Ng')
+    expect(renderedList).not.toContain('Brown')
+  })
+})


### PR DESCRIPTION
## Summary
- prevent selecting duplicate reference authors by filtering the selector list with a stable author key
- add unit coverage to lock the behavior for Authors and Editors tabs

## Why
- the selector list used a synthetic `data_id` that does not exist on already-selected authors, so duplicates were not filtered out

## Testing
- `npm run lint:frontend`
- `cd frontend && npm run test -- --runTestsByPath tests/components/ReferenceAuthorTab.test.tsx`
- repo pre-commit hooks also ran: `npm run lint` and `npm run tsc`
