### PR TITLE
[codex] add museum create flow tests

### DIFF
--- a/cypress/e2e/museum.cy.js
+++ b/cypress/e2e/museum.cy.js
@@ -11,13 +11,24 @@ const typeIfNotEmpty = (selector, value) => {
   cy.get(selector).type(value)
 }
 
+const openMuseumFromList = (institution, code) => {
+  cy.visit('/museum')
+  cy.get('[aria-label="Filter by Institution"]', { timeout: 10000 }).clear()
+  cy.get('[aria-label="Filter by Institution"]').type(institution)
+  cy.contains('td', institution, { timeout: 10000 })
+    .should('be.visible')
+    .closest('tr')
+    .within(() => {
+      cy.get(`[data-cy="details-button-${code}"]`).click()
+    })
+}
+
 const fillMuseumForm = ({ code, institution, city, country, altName, state, stateCode }) => {
   typeIfNotEmpty('#institution-textfield', institution)
   typeIfNotEmpty('#city-textfield', city)
   typeIfNotEmpty('#museum-textfield', code)
 
-  cy.get('#Country-multiselect').find('input').clear()
-  cy.get('#Country-multiselect').find('input').type(`${country}{enter}`)
+  cy.contains('Choose a country', { timeout: 10000 }).parent().type(`${country}{enter}`)
 
   typeIfNotEmpty('#alt_int_name-textfield', altName)
   typeIfNotEmpty('#state-textfield', state)
@@ -29,7 +40,7 @@ const fillCreateMuseumModal = ({ code, institution, city, country, altName, stat
   typeIfNotEmpty('input[name="alt_int_name"]', altName)
   typeIfNotEmpty('input[name="city"]', city)
 
-  cy.contains('label', 'Country').parent().as('countryField')
+  cy.get('input[name="country"]').parent().as('countryField')
   cy.get('@countryField').find('[role="button"]').click()
   cy.contains('li', country).click()
 
@@ -49,6 +60,8 @@ describe('Museum e2e flows', () => {
 
   it('shows museum list for authorized users', () => {
     cy.visit('/museum')
+    cy.get('[aria-label="Filter by Institution"]', { timeout: 10000 }).clear()
+    cy.get('[aria-label="Filter by Institution"]').type('Australian Museum')
     cy.contains('td', 'Australian Museum', { timeout: 10000 })
       .should('be.visible')
       .closest('tr')
@@ -83,7 +96,7 @@ describe('Museum e2e flows', () => {
 
     cy.intercept('PUT', '**/museum').as('saveMuseum')
 
-    cy.visit('/museum/AM')
+    openMuseumFromList('Australian Museum', 'AM')
     cy.contains('Australian Museum', { timeout: 10000 }).should('be.visible')
     cy.get('[id=edit-button]').should('be.visible').click()
     typeIfNotEmpty('#alt_int_name-textfield', altName)
@@ -101,6 +114,8 @@ describe('Museum e2e flows', () => {
     cy.get('[id=edit-button]').click()
 
     cy.contains('Select Museum').click()
+    cy.get('[aria-label="Filter by Institution"]', { timeout: 10000 }).clear()
+    cy.get('[aria-label="Filter by Institution"]').type('Australian Museum')
     cy.get('[data-cy="add-button-AM"]', { timeout: 10000 }).should('be.visible').click()
     cy.contains('Australian Museum').should('be.visible')
     cy.contains('button', 'Close').click()

--- a/cypress/e2e/museum.cy.js
+++ b/cypress/e2e/museum.cy.js
@@ -28,7 +28,8 @@ const fillMuseumForm = ({ code, institution, city, country, altName, state, stat
   typeIfNotEmpty('#city-textfield', city)
   typeIfNotEmpty('#museum-textfield', code)
 
-  cy.contains('Choose a country', { timeout: 10000 }).parent().type(`${country}{enter}`)
+  cy.contains('Choose a country', { timeout: 10000 }).parent().type(country)
+  cy.contains(country).click()
 
   typeIfNotEmpty('#alt_int_name-textfield', altName)
   typeIfNotEmpty('#state-textfield', state)
@@ -40,8 +41,7 @@ const fillCreateMuseumModal = ({ code, institution, city, country, altName, stat
     typeIfNotEmpty('input[name="institution"]', institution)
     typeIfNotEmpty('input[name="alt_int_name"]', altName)
     typeIfNotEmpty('input[name="city"]', city)
-
-    cy.get('input[name="country"]').parents().find('[role="button"]').first().click()
+    cy.get('[name="country"]').parent().click({ force: true })
   })
 
   cy.contains('li', country).click()
@@ -74,7 +74,9 @@ describe('Museum e2e flows', () => {
   })
 
   it('shows museum list for authorized users', () => {
+    cy.intercept('GET', '**/museum/all').as('getMuseums')
     cy.visit('/museum')
+    cy.wait('@getMuseums')
     cy.get('[aria-label="Filter by Institution"]', { timeout: 10000 }).clear()
     cy.get('[aria-label="Filter by Institution"]').type(seedMuseum.institution)
     cy.contains(seedMuseum.institution, { timeout: 10000 })
@@ -86,6 +88,7 @@ describe('Museum e2e flows', () => {
   })
 
   it('creates a new museum and lands on its details view', () => {
+    cy.intercept('GET', '**/museum/all').as('getMuseums')
     const code = buildMuseumCode('MT')
     const institution = `Museum Test ${code}`
     const city = 'Helsinki'
@@ -94,6 +97,7 @@ describe('Museum e2e flows', () => {
     cy.intercept('PUT', '**/museum').as('saveMuseum')
 
     cy.visit('/museum/new')
+    cy.wait('@getMuseums')
     cy.get('#institution-textfield', { timeout: 10000 }).should('be.visible')
     fillMuseumForm({ code, institution, city, country })
 
@@ -125,11 +129,13 @@ describe('Museum e2e flows', () => {
 
   it('links an existing museum to a locality and saves the locality', () => {
     cy.intercept('PUT', '**/locality').as('saveLocality')
+    cy.intercept('GET', '**/museum/all').as('getMuseums')
 
     cy.visit('/locality/20920?tab=9')
     cy.get('[id=edit-button]').click()
 
     cy.contains('Select Museum').click()
+    cy.wait('@getMuseums')
     cy.get('[aria-label="Filter by Institution"]', { timeout: 10000 }).clear()
     cy.get('[aria-label="Filter by Institution"]').type(seedMuseum.institution)
     cy.get(`[data-cy="add-button-${seedMuseum.code}"]`, { timeout: 10000 }).should('be.visible').click()

--- a/cypress/e2e/museum.cy.js
+++ b/cypress/e2e/museum.cy.js
@@ -49,7 +49,12 @@ const fillCreateMuseumModal = ({ code, institution, city, country, altName, stat
   cy.get('.modal-content').within(() => {
     cy.get('input[name="country"]').should('have.value', country)
     typeIfNotEmpty('input[name="state"]', state)
-    typeIfNotEmpty('input[name="state_code"]', stateCode)
+    if (stateCode !== undefined && stateCode !== null) {
+      typeIfNotEmpty('input[name="state_code"]', stateCode)
+    } else {
+      cy.get('input[name="state_code"]').clear()
+      cy.get('input[name="state_code"]').type(' {backspace}')
+    }
     typeIfNotEmpty('input[name="museum"]', code)
   })
 }

--- a/cypress/e2e/museum.cy.js
+++ b/cypress/e2e/museum.cy.js
@@ -53,6 +53,7 @@ const fillCreateMuseumModal = ({ code, institution, city, country, altName, stat
   })
 }
 
+const apiBaseUrl = Cypress.env('apiBaseUrl') ?? 'http://localhost:4000'
 let seedMuseum = { code: 'AM', institution: 'Australian Museum' }
 
 before(() => {
@@ -68,7 +69,7 @@ before(() => {
     }
     cy.request({
       method: 'PUT',
-      url: '/museum',
+      url: `${apiBaseUrl}/museum`,
       headers: { Authorization: `Bearer ${token}` },
       body: {
         museum: {

--- a/cypress/e2e/museum.cy.js
+++ b/cypress/e2e/museum.cy.js
@@ -41,7 +41,7 @@ const fillCreateMuseumModal = ({ code, institution, city, country, altName, stat
     typeIfNotEmpty('input[name="institution"]', institution)
     typeIfNotEmpty('input[name="alt_int_name"]', altName)
     typeIfNotEmpty('input[name="city"]', city)
-    cy.contains('Country').parent().type(country)
+    cy.get('#create-museum-country').click({ force: true })
   })
 
   cy.get('ul[role="listbox"]', { timeout: 10000 }).contains(country).click()

--- a/cypress/e2e/museum.cy.js
+++ b/cypress/e2e/museum.cy.js
@@ -15,7 +15,7 @@ const openMuseumFromList = (institution, code) => {
   cy.visit('/museum')
   cy.get('[aria-label="Filter by Institution"]', { timeout: 10000 }).clear()
   cy.get('[aria-label="Filter by Institution"]').type(institution)
-  cy.contains('td', institution, { timeout: 10000 })
+  cy.contains(institution, { timeout: 10000 })
     .should('be.visible')
     .closest('tr')
     .within(() => {
@@ -36,21 +36,36 @@ const fillMuseumForm = ({ code, institution, city, country, altName, state, stat
 }
 
 const fillCreateMuseumModal = ({ code, institution, city, country, altName, state, stateCode }) => {
-  typeIfNotEmpty('input[name="institution"]', institution)
-  typeIfNotEmpty('input[name="alt_int_name"]', altName)
-  typeIfNotEmpty('input[name="city"]', city)
+  cy.get('.modal-content').within(() => {
+    typeIfNotEmpty('input[name="institution"]', institution)
+    typeIfNotEmpty('input[name="alt_int_name"]', altName)
+    typeIfNotEmpty('input[name="city"]', city)
 
-  cy.get('input[name="country"]').parent().as('countryField')
-  cy.get('@countryField').find('[role="button"]').click()
+    cy.get('input[name="country"]').parents().find('[role="button"]').first().click()
+  })
+
   cy.contains('li', country).click()
 
-  typeIfNotEmpty('input[name="state"]', state)
-  typeIfNotEmpty('input[name="state_code"]', stateCode)
-  typeIfNotEmpty('input[name="museum"]', code)
+  cy.get('.modal-content').within(() => {
+    typeIfNotEmpty('input[name="state"]', state)
+    typeIfNotEmpty('input[name="state_code"]', stateCode)
+    typeIfNotEmpty('input[name="museum"]', code)
+  })
 }
+
+let seedMuseum = { code: 'AM', institution: 'Australian Museum' }
 
 before(() => {
   cy.resetDatabase()
+  cy.request('/museum/all').then(response => {
+    const museums = response.body ?? []
+    const pick =
+      museums.find(item => item?.institution && item.institution !== '[missing details]' && item?.museum) ??
+      museums.find(item => item?.museum)
+    if (pick) {
+      seedMuseum = { code: pick.museum, institution: pick.institution || pick.museum }
+    }
+  })
 })
 
 describe('Museum e2e flows', () => {
@@ -61,12 +76,12 @@ describe('Museum e2e flows', () => {
   it('shows museum list for authorized users', () => {
     cy.visit('/museum')
     cy.get('[aria-label="Filter by Institution"]', { timeout: 10000 }).clear()
-    cy.get('[aria-label="Filter by Institution"]').type('Australian Museum')
-    cy.contains('td', 'Australian Museum', { timeout: 10000 })
+    cy.get('[aria-label="Filter by Institution"]').type(seedMuseum.institution)
+    cy.contains(seedMuseum.institution, { timeout: 10000 })
       .should('be.visible')
       .closest('tr')
       .within(() => {
-        cy.get('[data-cy="details-button-AM"]').should('be.visible')
+        cy.get(`[data-cy="details-button-${seedMuseum.code}"]`).should('be.visible')
       })
   })
 
@@ -82,6 +97,7 @@ describe('Museum e2e flows', () => {
     cy.get('#institution-textfield', { timeout: 10000 }).should('be.visible')
     fillMuseumForm({ code, institution, city, country })
 
+    cy.get('[id=write-button]').should('not.be.disabled')
     cy.get('[id=write-button]').click()
     cy.wait('@saveMuseum').its('response.statusCode').should('eq', 200)
 
@@ -96,8 +112,8 @@ describe('Museum e2e flows', () => {
 
     cy.intercept('PUT', '**/museum').as('saveMuseum')
 
-    openMuseumFromList('Australian Museum', 'AM')
-    cy.contains('Australian Museum', { timeout: 10000 }).should('be.visible')
+    openMuseumFromList(seedMuseum.institution, seedMuseum.code)
+    cy.contains(seedMuseum.institution, { timeout: 10000 }).should('be.visible')
     cy.get('[id=edit-button]').should('be.visible').click()
     typeIfNotEmpty('#alt_int_name-textfield', altName)
 
@@ -115,8 +131,8 @@ describe('Museum e2e flows', () => {
 
     cy.contains('Select Museum').click()
     cy.get('[aria-label="Filter by Institution"]', { timeout: 10000 }).clear()
-    cy.get('[aria-label="Filter by Institution"]').type('Australian Museum')
-    cy.get('[data-cy="add-button-AM"]', { timeout: 10000 }).should('be.visible').click()
+    cy.get('[aria-label="Filter by Institution"]').type(seedMuseum.institution)
+    cy.get(`[data-cy="add-button-${seedMuseum.code}"]`, { timeout: 10000 }).should('be.visible').click()
     cy.contains('Australian Museum').should('be.visible')
     cy.contains('button', 'Close').click()
 

--- a/cypress/e2e/museum.cy.js
+++ b/cypress/e2e/museum.cy.js
@@ -180,7 +180,7 @@ describe('Museum e2e flows', () => {
     cy.get('[id=edit-button]').click()
 
     cy.contains('Create Museum').click()
-    fillCreateMuseumModal({ code, institution, city, country, stateCode: '' })
+    fillCreateMuseumModal({ code, institution, city, country, stateCode: 'NA' })
     cy.contains('button', 'Save').click()
 
     cy.wait('@saveMuseum').then(({ response }) => {

--- a/cypress/e2e/museum.cy.js
+++ b/cypress/e2e/museum.cy.js
@@ -41,10 +41,10 @@ const fillCreateMuseumModal = ({ code, institution, city, country, altName, stat
     typeIfNotEmpty('input[name="institution"]', institution)
     typeIfNotEmpty('input[name="alt_int_name"]', altName)
     typeIfNotEmpty('input[name="city"]', city)
-    cy.contains('Country').parent().click({ force: true })
+    cy.contains('Country').parent().type(country)
   })
 
-  cy.contains('li', country, { timeout: 10000 }).click()
+  cy.get('ul[role="listbox"]', { timeout: 10000 }).contains(country).click()
 
   cy.get('.modal-content').within(() => {
     typeIfNotEmpty('input[name="state"]', state)

--- a/cypress/e2e/museum.cy.js
+++ b/cypress/e2e/museum.cy.js
@@ -58,7 +58,7 @@ let seedMuseum = { code: 'AM', institution: 'Australian Museum' }
 before(() => {
   cy.resetDatabase()
   cy.request('/museum/all').then(response => {
-    const museums = response.body ?? []
+    const museums = Array.isArray(response.body) ? response.body : response.body?.data ?? []
     const pick =
       museums.find(item => item?.institution && item.institution !== '[missing details]' && item?.museum) ??
       museums.find(item => item?.museum)

--- a/cypress/e2e/museum.cy.js
+++ b/cypress/e2e/museum.cy.js
@@ -1,0 +1,147 @@
+const buildMuseumCode = prefix => {
+  const suffix = String(Date.now()).slice(-4)
+  return `${prefix}${suffix}`.slice(0, 10)
+}
+
+const fillMuseumForm = ({ code, institution, city, country, altName, state, stateCode }) => {
+  cy.get('#institution-textfield').clear()
+  cy.get('#institution-textfield').type(institution)
+  cy.get('#city-textfield').clear()
+  cy.get('#city-textfield').type(city)
+  cy.get('#museum-textfield').clear()
+  cy.get('#museum-textfield').type(code)
+
+  cy.get('#Country-multiselect input').clear()
+  cy.get('#Country-multiselect input').type(`${country}{enter}`)
+
+  if (altName !== undefined) {
+    cy.get('#alt_int_name-textfield').clear()
+    cy.get('#alt_int_name-textfield').type(altName)
+  }
+
+  if (state !== undefined) {
+    cy.get('#state-textfield').clear()
+    cy.get('#state-textfield').type(state)
+  }
+
+  if (stateCode !== undefined) {
+    cy.get('#state_code-textfield').clear()
+    cy.get('#state_code-textfield').type(stateCode)
+  }
+}
+
+const fillCreateMuseumModal = ({ code, institution, city, country, altName, state, stateCode }) => {
+  cy.get('input[name="institution"]').clear()
+  cy.get('input[name="institution"]').type(institution)
+  cy.get('input[name="alt_int_name"]').clear()
+  cy.get('input[name="alt_int_name"]').type(altName ?? '')
+  cy.get('input[name="city"]').clear()
+  cy.get('input[name="city"]').type(city)
+
+  cy.contains('label', 'Country').parent().as('countryField')
+  cy.get('@countryField').find('[role="button"]').click()
+  cy.contains('li', country).click()
+
+  cy.get('input[name="state"]').clear()
+  cy.get('input[name="state"]').type(state ?? '')
+  cy.get('input[name="state_code"]').clear()
+  cy.get('input[name="state_code"]').type(stateCode ?? '')
+  cy.get('input[name="museum"]').clear()
+  cy.get('input[name="museum"]').type(code)
+}
+
+before(() => {
+  cy.resetDatabase()
+})
+
+describe('Museum e2e flows', () => {
+  beforeEach(() => {
+    cy.loginWithSession('testSu')
+  })
+
+  it('shows museum list for authorized users', () => {
+    cy.visit('/museum')
+    cy.get('[data-cy="details-button-AM"]').should('be.visible')
+    cy.contains('Australian Museum').should('be.visible')
+  })
+
+  it('creates a new museum and lands on its details view', () => {
+    const code = buildMuseumCode('MT')
+    const institution = `Museum Test ${code}`
+    const city = 'Helsinki'
+    const country = 'Finland'
+
+    cy.intercept('PUT', '**/museum').as('saveMuseum')
+
+    cy.visit('/museum/new')
+    fillMuseumForm({ code, institution, city, country })
+
+    cy.get('[id=write-button]').click()
+    cy.wait('@saveMuseum').its('response.statusCode').should('eq', 200)
+
+    cy.location('pathname').should('eq', `/museum/${code}`)
+    cy.contains(institution).should('be.visible')
+    cy.contains(city).should('be.visible')
+    cy.contains(country).should('be.visible')
+  })
+
+  it('edits an existing museum and persists changes', () => {
+    const altName = `Alt name ${Date.now()}`
+
+    cy.intercept('PUT', '**/museum').as('saveMuseum')
+
+    cy.visit('/museum/AM')
+    cy.get('[id=edit-button]').click()
+    cy.get('#alt_int_name-textfield').clear()
+    cy.get('#alt_int_name-textfield').type(altName)
+
+    cy.get('[id=write-button]').click()
+    cy.wait('@saveMuseum').its('response.statusCode').should('eq', 200)
+
+    cy.contains(altName).should('be.visible')
+  })
+
+  it('links an existing museum to a locality and saves the locality', () => {
+    cy.intercept('PUT', '**/locality').as('saveLocality')
+
+    cy.visit('/locality/20920?tab=9')
+    cy.get('[id=edit-button]').click()
+
+    cy.contains('Select Museum').click()
+    cy.get('[data-cy="add-button-AM"]').click()
+    cy.contains('Australian Museum').should('be.visible')
+    cy.contains('button', 'Close').click()
+
+    cy.addReferenceAndSave()
+    cy.wait('@saveLocality').its('response.statusCode').should('eq', 200)
+
+    cy.visit('/locality/20920?tab=9')
+    cy.contains('Australian Museum').should('be.visible')
+  })
+
+  it('creates a museum from the locality modal and links it', () => {
+    const code = buildMuseumCode('LM')
+    const institution = `Locality Museum ${code}`
+    const city = 'Turku'
+    const country = 'Finland'
+
+    cy.intercept('PUT', '**/museum').as('saveMuseum')
+    cy.intercept('PUT', '**/locality').as('saveLocality')
+
+    cy.visit('/locality/20920?tab=9')
+    cy.get('[id=edit-button]').click()
+
+    cy.contains('Create Museum').click()
+    fillCreateMuseumModal({ code, institution, city, country })
+    cy.contains('button', 'Save').click()
+
+    cy.wait('@saveMuseum').its('response.statusCode').should('eq', 200)
+    cy.contains(institution).should('be.visible')
+
+    cy.addReferenceAndSave()
+    cy.wait('@saveLocality').its('response.statusCode').should('eq', 200)
+
+    cy.visit('/locality/20920?tab=9')
+    cy.contains(institution).should('be.visible')
+  })
+})

--- a/cypress/e2e/museum.cy.js
+++ b/cypress/e2e/museum.cy.js
@@ -41,10 +41,10 @@ const fillCreateMuseumModal = ({ code, institution, city, country, altName, stat
     typeIfNotEmpty('input[name="institution"]', institution)
     typeIfNotEmpty('input[name="alt_int_name"]', altName)
     typeIfNotEmpty('input[name="city"]', city)
-    cy.get('[name="country"]').parent().click({ force: true })
+    cy.contains('Country').parent().click({ force: true })
   })
 
-  cy.get('ul[role="listbox"]', { timeout: 10000 }).contains(country).click()
+  cy.contains('li', country, { timeout: 10000 }).click()
 
   cy.get('.modal-content').within(() => {
     typeIfNotEmpty('input[name="state"]', state)
@@ -151,14 +151,14 @@ describe('Museum e2e flows', () => {
     cy.get('[aria-label="Filter by Institution"]', { timeout: 10000 }).clear()
     cy.get('[aria-label="Filter by Institution"]').type(seedMuseum.institution)
     cy.get(`[data-cy="add-button-${seedMuseum.code}"]`, { timeout: 10000 }).should('be.visible').click()
-    cy.contains('Australian Museum').should('be.visible')
+    cy.contains(seedMuseum.institution).should('be.visible')
     cy.contains('button', 'Close').click()
 
     cy.addReferenceAndSave()
     cy.wait('@saveLocality').its('response.statusCode').should('eq', 200)
 
     cy.visit('/locality/20920?tab=9')
-    cy.contains('Australian Museum').should('be.visible')
+    cy.contains(seedMuseum.institution).should('be.visible')
   })
 
   it('creates a museum from the locality modal and links it', () => {

--- a/cypress/e2e/museum.cy.js
+++ b/cypress/e2e/museum.cy.js
@@ -29,7 +29,7 @@ const fillMuseumForm = ({ code, institution, city, country, altName, state, stat
   typeIfNotEmpty('#museum-textfield', code)
 
   cy.contains('Choose a country', { timeout: 10000 }).parent().type(country)
-  cy.contains(country).click()
+  cy.get('ul[role="listbox"]', { timeout: 10000 }).contains(country).click()
 
   typeIfNotEmpty('#alt_int_name-textfield', altName)
   typeIfNotEmpty('#state-textfield', state)
@@ -44,7 +44,7 @@ const fillCreateMuseumModal = ({ code, institution, city, country, altName, stat
     cy.get('[name="country"]').parent().click({ force: true })
   })
 
-  cy.contains('li', country).click()
+  cy.get('ul[role="listbox"]', { timeout: 10000 }).contains(country).click()
 
   cy.get('.modal-content').within(() => {
     typeIfNotEmpty('input[name="state"]', state)
@@ -57,14 +57,31 @@ let seedMuseum = { code: 'AM', institution: 'Australian Museum' }
 
 before(() => {
   cy.resetDatabase()
-  cy.request('/museum/all').then(response => {
-    const museums = Array.isArray(response.body) ? response.body : response.body?.data ?? []
-    const pick =
-      museums.find(item => item?.institution && item.institution !== '[missing details]' && item?.museum) ??
-      museums.find(item => item?.museum)
-    if (pick) {
-      seedMuseum = { code: pick.museum, institution: pick.institution || pick.museum }
+  cy.loginWithSession('testSu')
+  const code = buildMuseumCode('CYM')
+  seedMuseum = { code, institution: `Cypress Museum ${code}` }
+  cy.window().then(win => {
+    const userState = win.localStorage.getItem('userState')
+    const token = userState ? JSON.parse(userState).token : null
+    if (!token) {
+      throw new Error('Missing auth token for museum setup')
     }
+    cy.request({
+      method: 'PUT',
+      url: '/museum',
+      headers: { Authorization: `Bearer ${token}` },
+      body: {
+        museum: {
+          museum: seedMuseum.code,
+          institution: seedMuseum.institution,
+          city: 'Helsinki',
+          country: 'Finland',
+          alt_int_name: null,
+          state: null,
+          state_code: null,
+        },
+      },
+    })
   })
 })
 
@@ -74,9 +91,7 @@ describe('Museum e2e flows', () => {
   })
 
   it('shows museum list for authorized users', () => {
-    cy.intercept('GET', '**/museum/all').as('getMuseums')
     cy.visit('/museum')
-    cy.wait('@getMuseums')
     cy.get('[aria-label="Filter by Institution"]', { timeout: 10000 }).clear()
     cy.get('[aria-label="Filter by Institution"]').type(seedMuseum.institution)
     cy.contains(seedMuseum.institution, { timeout: 10000 })
@@ -88,7 +103,6 @@ describe('Museum e2e flows', () => {
   })
 
   it('creates a new museum and lands on its details view', () => {
-    cy.intercept('GET', '**/museum/all').as('getMuseums')
     const code = buildMuseumCode('MT')
     const institution = `Museum Test ${code}`
     const city = 'Helsinki'
@@ -97,7 +111,6 @@ describe('Museum e2e flows', () => {
     cy.intercept('PUT', '**/museum').as('saveMuseum')
 
     cy.visit('/museum/new')
-    cy.wait('@getMuseums')
     cy.get('#institution-textfield', { timeout: 10000 }).should('be.visible')
     fillMuseumForm({ code, institution, city, country })
 
@@ -129,13 +142,11 @@ describe('Museum e2e flows', () => {
 
   it('links an existing museum to a locality and saves the locality', () => {
     cy.intercept('PUT', '**/locality').as('saveLocality')
-    cy.intercept('GET', '**/museum/all').as('getMuseums')
 
     cy.visit('/locality/20920?tab=9')
     cy.get('[id=edit-button]').click()
 
     cy.contains('Select Museum').click()
-    cy.wait('@getMuseums')
     cy.get('[aria-label="Filter by Institution"]', { timeout: 10000 }).clear()
     cy.get('[aria-label="Filter by Institution"]').type(seedMuseum.institution)
     cy.get(`[data-cy="add-button-${seedMuseum.code}"]`, { timeout: 10000 }).should('be.visible').click()

--- a/cypress/e2e/museum.cy.js
+++ b/cypress/e2e/museum.cy.js
@@ -36,7 +36,7 @@ const fillMuseumForm = ({ code, institution, city, country, altName, state, stat
   typeIfNotEmpty('#state_code-textfield', stateCode)
 }
 
-const fillCreateMuseumModal = ({ code, institution, city, country, altName, state, stateCode }) => {
+  const fillCreateMuseumModal = ({ code, institution, city, country, altName, state, stateCode }) => {
   cy.get('.modal-content').within(() => {
     typeIfNotEmpty('input[name="institution"]', institution)
     typeIfNotEmpty('input[name="alt_int_name"]', altName)
@@ -180,7 +180,7 @@ describe('Museum e2e flows', () => {
     cy.get('[id=edit-button]').click()
 
     cy.contains('Create Museum').click()
-    fillCreateMuseumModal({ code, institution, city, country })
+    fillCreateMuseumModal({ code, institution, city, country, stateCode: '' })
     cy.contains('button', 'Save').click()
 
     cy.wait('@saveMuseum').then(({ response }) => {

--- a/cypress/e2e/museum.cy.js
+++ b/cypress/e2e/museum.cy.js
@@ -178,7 +178,9 @@ describe('Museum e2e flows', () => {
     fillCreateMuseumModal({ code, institution, city, country })
     cy.contains('button', 'Save').click()
 
-    cy.wait('@saveMuseum').its('response.statusCode').should('eq', 200)
+    cy.wait('@saveMuseum').then(({ response }) => {
+      expect(response?.statusCode).to.eq(200, `Museum create failed: ${JSON.stringify(response?.body)}`)
+    })
     cy.contains(institution).should('be.visible')
 
     cy.addReferenceAndSave()

--- a/cypress/e2e/museum.cy.js
+++ b/cypress/e2e/museum.cy.js
@@ -3,51 +3,39 @@ const buildMuseumCode = prefix => {
   return `${prefix}${suffix}`.slice(0, 10)
 }
 
+const typeIfNotEmpty = (selector, value) => {
+  if (value === undefined || value === null || value === '') {
+    return
+  }
+  cy.get(selector).clear()
+  cy.get(selector).type(value)
+}
+
 const fillMuseumForm = ({ code, institution, city, country, altName, state, stateCode }) => {
-  cy.get('#institution-textfield').clear()
-  cy.get('#institution-textfield').type(institution)
-  cy.get('#city-textfield').clear()
-  cy.get('#city-textfield').type(city)
-  cy.get('#museum-textfield').clear()
-  cy.get('#museum-textfield').type(code)
+  typeIfNotEmpty('#institution-textfield', institution)
+  typeIfNotEmpty('#city-textfield', city)
+  typeIfNotEmpty('#museum-textfield', code)
 
-  cy.get('#Country-multiselect input').clear()
-  cy.get('#Country-multiselect input').type(`${country}{enter}`)
+  cy.get('#Country-multiselect').find('input').clear()
+  cy.get('#Country-multiselect').find('input').type(`${country}{enter}`)
 
-  if (altName !== undefined) {
-    cy.get('#alt_int_name-textfield').clear()
-    cy.get('#alt_int_name-textfield').type(altName)
-  }
-
-  if (state !== undefined) {
-    cy.get('#state-textfield').clear()
-    cy.get('#state-textfield').type(state)
-  }
-
-  if (stateCode !== undefined) {
-    cy.get('#state_code-textfield').clear()
-    cy.get('#state_code-textfield').type(stateCode)
-  }
+  typeIfNotEmpty('#alt_int_name-textfield', altName)
+  typeIfNotEmpty('#state-textfield', state)
+  typeIfNotEmpty('#state_code-textfield', stateCode)
 }
 
 const fillCreateMuseumModal = ({ code, institution, city, country, altName, state, stateCode }) => {
-  cy.get('input[name="institution"]').clear()
-  cy.get('input[name="institution"]').type(institution)
-  cy.get('input[name="alt_int_name"]').clear()
-  cy.get('input[name="alt_int_name"]').type(altName ?? '')
-  cy.get('input[name="city"]').clear()
-  cy.get('input[name="city"]').type(city)
+  typeIfNotEmpty('input[name="institution"]', institution)
+  typeIfNotEmpty('input[name="alt_int_name"]', altName)
+  typeIfNotEmpty('input[name="city"]', city)
 
   cy.contains('label', 'Country').parent().as('countryField')
   cy.get('@countryField').find('[role="button"]').click()
   cy.contains('li', country).click()
 
-  cy.get('input[name="state"]').clear()
-  cy.get('input[name="state"]').type(state ?? '')
-  cy.get('input[name="state_code"]').clear()
-  cy.get('input[name="state_code"]').type(stateCode ?? '')
-  cy.get('input[name="museum"]').clear()
-  cy.get('input[name="museum"]').type(code)
+  typeIfNotEmpty('input[name="state"]', state)
+  typeIfNotEmpty('input[name="state_code"]', stateCode)
+  typeIfNotEmpty('input[name="museum"]', code)
 }
 
 before(() => {
@@ -61,8 +49,12 @@ describe('Museum e2e flows', () => {
 
   it('shows museum list for authorized users', () => {
     cy.visit('/museum')
-    cy.get('[data-cy="details-button-AM"]').should('be.visible')
-    cy.contains('Australian Museum').should('be.visible')
+    cy.contains('td', 'Australian Museum', { timeout: 10000 })
+      .should('be.visible')
+      .closest('tr')
+      .within(() => {
+        cy.get('[data-cy="details-button-AM"]').should('be.visible')
+      })
   })
 
   it('creates a new museum and lands on its details view', () => {
@@ -74,6 +66,7 @@ describe('Museum e2e flows', () => {
     cy.intercept('PUT', '**/museum').as('saveMuseum')
 
     cy.visit('/museum/new')
+    cy.get('#institution-textfield', { timeout: 10000 }).should('be.visible')
     fillMuseumForm({ code, institution, city, country })
 
     cy.get('[id=write-button]').click()
@@ -91,9 +84,9 @@ describe('Museum e2e flows', () => {
     cy.intercept('PUT', '**/museum').as('saveMuseum')
 
     cy.visit('/museum/AM')
-    cy.get('[id=edit-button]').click()
-    cy.get('#alt_int_name-textfield').clear()
-    cy.get('#alt_int_name-textfield').type(altName)
+    cy.contains('Australian Museum', { timeout: 10000 }).should('be.visible')
+    cy.get('[id=edit-button]').should('be.visible').click()
+    typeIfNotEmpty('#alt_int_name-textfield', altName)
 
     cy.get('[id=write-button]').click()
     cy.wait('@saveMuseum').its('response.statusCode').should('eq', 200)
@@ -108,7 +101,7 @@ describe('Museum e2e flows', () => {
     cy.get('[id=edit-button]').click()
 
     cy.contains('Select Museum').click()
-    cy.get('[data-cy="add-button-AM"]').click()
+    cy.get('[data-cy="add-button-AM"]', { timeout: 10000 }).should('be.visible').click()
     cy.contains('Australian Museum').should('be.visible')
     cy.contains('button', 'Close').click()
 

--- a/cypress/e2e/museum.cy.js
+++ b/cypress/e2e/museum.cy.js
@@ -77,9 +77,9 @@ before(() => {
           institution: seedMuseum.institution,
           city: 'Helsinki',
           country: 'Finland',
-          alt_int_name: null,
-          state: null,
-          state_code: null,
+          alt_int_name: '',
+          state: '',
+          state_code: '',
         },
       },
     })

--- a/cypress/e2e/museum.cy.js
+++ b/cypress/e2e/museum.cy.js
@@ -47,6 +47,7 @@ const fillCreateMuseumModal = ({ code, institution, city, country, altName, stat
   cy.get('ul[role="listbox"]', { timeout: 10000 }).contains(country).click()
 
   cy.get('.modal-content').within(() => {
+    cy.get('input[name="country"]').should('have.value', country)
     typeIfNotEmpty('input[name="state"]', state)
     typeIfNotEmpty('input[name="state_code"]', stateCode)
     typeIfNotEmpty('input[name="museum"]', code)

--- a/frontend/src/components/Locality/Tabs/MuseumTab.tsx
+++ b/frontend/src/components/Locality/Tabs/MuseumTab.tsx
@@ -166,6 +166,7 @@ export const MuseumTab = () => {
         <TextField
           select
           label="Country"
+          id="create-museum-country"
           defaultValue=""
           {...register('country', { required: 'Country is required' })}
           error={Boolean(errors.country)}

--- a/frontend/src/components/Locality/Tabs/MuseumTab.tsx
+++ b/frontend/src/components/Locality/Tabs/MuseumTab.tsx
@@ -1,16 +1,54 @@
-import { Editable, LocalityDetailsType, Museum } from '@/shared/types'
+import { Editable, LocalityDetailsType, Museum, ValidationErrors } from '@/shared/types'
 import { EditableTable } from '@/components/DetailView/common/EditableTable'
 import { Grouped } from '@/components/DetailView/common/tabLayoutHelpers'
 import { SelectingTable } from '@/components/DetailView/common/SelectingTable'
 import { useDetailContext } from '@/components/DetailView/Context/DetailContext'
-import { useGetAllMuseumsQuery } from '@/redux/museumReducer'
-import { Box } from '@mui/material'
+import { useEditMuseumMutation, useGetAllMuseumsQuery } from '@/redux/museumReducer'
+import { Box, MenuItem, TextField } from '@mui/material'
 import { MRT_ColumnDef } from 'material-react-table'
 import { skipToken } from '@reduxjs/toolkit/query'
+import { EditingModal } from '@/components/DetailView/common/EditingModal'
+import { useForm } from 'react-hook-form'
+import { useNotify } from '@/hooks/notification'
+import { validCountries } from '@/shared/validators/countryList'
 
 export const MuseumTab = () => {
   const { mode, editData, setEditData } = useDetailContext<LocalityDetailsType>()
-  const { data: museumData, isError } = useGetAllMuseumsQuery(mode.read ? skipToken : undefined)
+  const {
+    data: museumData,
+    isError,
+    refetch: refetchMuseums,
+  } = useGetAllMuseumsQuery(mode.read ? skipToken : undefined)
+  const [editMuseumRequest, { isLoading: isSavingMuseum }] = useEditMuseumMutation()
+  const { notify } = useNotify()
+
+  type CreateMuseumForm = {
+    institution: string
+    alt_int_name?: string
+    city: string
+    country: string
+    state?: string
+    state_code?: string
+    museum: string
+  }
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    reset,
+  } = useForm<CreateMuseumForm>({
+    mode: 'onSubmit',
+    defaultValues: {
+      institution: '',
+      alt_int_name: '',
+      city: '',
+      country: '',
+      state: '',
+      state_code: '',
+      museum: '',
+    },
+  })
 
   const columns: MRT_ColumnDef<Museum>[] = [
     {
@@ -30,6 +68,145 @@ export const MuseumTab = () => {
       header: 'Country',
     },
   ]
+
+  const onCreateMuseumSave = async () => {
+    let shouldClose = false
+
+    await handleSubmit(
+      async values => {
+        const normalized: CreateMuseumForm = {
+          institution: values.institution.trim(),
+          alt_int_name: values.alt_int_name?.trim() ?? '',
+          city: values.city.trim(),
+          country: values.country.trim(),
+          state: values.state?.trim() ?? '',
+          state_code: values.state_code?.trim() ?? '',
+          museum: values.museum.trim(),
+        }
+
+        try {
+          const { museum: museumId } = await editMuseumRequest({
+            ...normalized,
+            alt_int_name: normalized.alt_int_name || null,
+            state: normalized.state || null,
+            state_code: normalized.state_code || null,
+          } as Museum).unwrap()
+
+          const refetchResult = await refetchMuseums()
+          const refreshedMuseums = refetchResult.data ?? museumData ?? []
+          const resolvedMuseum =
+            refreshedMuseums.find(museum => museum.museum === museumId) ??
+            ({
+              ...normalized,
+              museum: museumId,
+              alt_int_name: normalized.alt_int_name || null,
+              state: normalized.state || null,
+              state_code: normalized.state_code || null,
+            } as Museum)
+
+          if (editData.now_mus.some(link => link.museum === museumId)) {
+            notify('Museum already linked to this locality.', 'warning')
+            shouldClose = true
+            return
+          }
+
+          setEditData({
+            ...editData,
+            now_mus: [
+              ...editData.now_mus,
+              { lid: editData.lid, museum: museumId, com_mlist: resolvedMuseum, rowState: 'new' },
+            ],
+          })
+          reset()
+          notify('Museum created and linked to locality.', 'success')
+          shouldClose = true
+        } catch (error) {
+          const validationError = error as ValidationErrors
+          if (validationError?.data?.length) {
+            notify('Following validators failed: ' + validationError.data.map(e => e.name).join(', '), 'error')
+          } else {
+            notify('Failed to create museum.', 'error')
+          }
+          shouldClose = false
+        }
+      },
+      submissionErrors => {
+        const firstError = Object.values(submissionErrors)[0]
+        if (firstError?.message) notify(firstError.message, 'error')
+        shouldClose = false
+      }
+    )()
+
+    return shouldClose
+  }
+
+  const createMuseumModal = (
+    <EditingModal buttonText="Create Museum" onSave={onCreateMuseumSave}>
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: '1em' }}>
+        <TextField
+          {...register('institution', { required: 'Institution is required' })}
+          label="Institution"
+          required
+          error={Boolean(errors.institution)}
+          helperText={errors.institution?.message}
+        />
+        <TextField
+          {...register('alt_int_name')}
+          label="Alt. name"
+          error={Boolean(errors.alt_int_name)}
+          helperText={errors.alt_int_name?.message}
+        />
+        <TextField
+          {...register('city', { required: 'City is required' })}
+          label="City"
+          required
+          error={Boolean(errors.city)}
+          helperText={errors.city?.message}
+        />
+        <TextField
+          select
+          label="Country"
+          defaultValue=""
+          {...register('country', { required: 'Country is required' })}
+          error={Boolean(errors.country)}
+          helperText={errors.country?.message}
+        >
+          {['', ...validCountries].map(country => (
+            <MenuItem key={country} value={country}>
+              {country || 'Select country'}
+            </MenuItem>
+          ))}
+        </TextField>
+        <TextField
+          {...register('state')}
+          label="State"
+          error={Boolean(errors.state)}
+          helperText={errors.state?.message}
+        />
+        <TextField
+          {...register('state_code', {
+            validate: value => {
+              if (!value) return true
+              return value.length <= 5 || 'State code must contain a maximum of 5 characters'
+            },
+          })}
+          label="State code"
+          error={Boolean(errors.state_code)}
+          helperText={errors.state_code?.message}
+        />
+        <TextField
+          {...register('museum', {
+            required: 'Museum code is required',
+            validate: value => (value.includes(' ') ? 'Museum code must not contain a space' : true),
+          })}
+          label="Museum code"
+          required
+          error={Boolean(errors.museum)}
+          helperText={errors.museum?.message}
+        />
+      </Box>
+    </EditingModal>
+  )
 
   return (
     <Grouped title="Museums">
@@ -53,6 +230,9 @@ export const MuseumTab = () => {
               })
             }}
           />
+          <Box display="flex" alignItems="center">
+            <Box sx={{ opacity: isSavingMuseum ? 0.7 : 1 }}>{createMuseumModal}</Box>
+          </Box>
         </Box>
       )}
       <EditableTable<Editable<Museum>, LocalityDetailsType>

--- a/frontend/src/components/Locality/Tabs/__tests__/MuseumTab.test.tsx
+++ b/frontend/src/components/Locality/Tabs/__tests__/MuseumTab.test.tsx
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { type ReactNode } from 'react'
+import { MuseumTab } from '../MuseumTab'
+import { useDetailContext, modeOptionToMode } from '@/components/DetailView/Context/DetailContext'
+import { useEditMuseumMutation, useGetAllMuseumsQuery } from '@/redux/museumReducer'
+import { useNotify } from '@/hooks/notification'
+import type { Museum } from '@/shared/types'
+
+jest.mock('@/components/DetailView/Context/DetailContext', () => ({
+  useDetailContext: jest.fn(),
+  modeOptionToMode: {
+    new: { read: false, staging: false, new: true, option: 'new' },
+    read: { read: true, staging: false, new: false, option: 'read' },
+    edit: { read: false, staging: false, new: false, option: 'edit' },
+    'staging-edit': { read: false, staging: true, new: false, option: 'staging-edit' },
+    'staging-new': { read: false, staging: true, new: true, option: 'staging-new' },
+  },
+}))
+
+jest.mock('@/redux/museumReducer', () => ({
+  useGetAllMuseumsQuery: jest.fn(),
+  useEditMuseumMutation: jest.fn(),
+}))
+
+jest.mock('@/hooks/notification', () => ({
+  useNotify: jest.fn(),
+}))
+
+jest.mock('@/components/DetailView/common/tabLayoutHelpers', () => ({
+  Grouped: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}))
+
+jest.mock('@/components/DetailView/common/EditableTable', () => ({
+  EditableTable: () => <div data-testid="editable-table" />,
+}))
+
+jest.mock('@/components/DetailView/common/SelectingTable', () => ({
+  SelectingTable: () => <div data-testid="selecting-table" />,
+}))
+
+jest.mock('@/components/DetailView/common/EditingModal', () => ({
+  EditingModal: ({
+    children,
+    buttonText,
+    onSave,
+  }: {
+    children: ReactNode
+    buttonText: string
+    onSave?: () => Promise<boolean>
+  }) => (
+    <div data-testid="editing-modal" data-button-text={buttonText}>
+      {children}
+      {onSave && (
+        <button type="button" onClick={() => void onSave()}>
+          Save
+        </button>
+      )}
+    </div>
+  ),
+}))
+
+const mockUseDetailContext = useDetailContext as jest.MockedFunction<typeof useDetailContext>
+const mockUseGetAllMuseumsQuery = useGetAllMuseumsQuery as jest.MockedFunction<typeof useGetAllMuseumsQuery>
+const mockUseEditMuseumMutation = useEditMuseumMutation as jest.MockedFunction<typeof useEditMuseumMutation>
+const mockUseNotify = useNotify as jest.MockedFunction<typeof useNotify>
+
+describe('MuseumTab create flow', () => {
+  const setEditData = jest.fn<(value: unknown) => void>()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseNotify.mockReturnValue({ notify: jest.fn() } as never)
+  })
+
+  it('creates a museum and links it to the locality', async () => {
+    const createdMuseum = {
+      museum: 'AM',
+      institution: 'Test Institute',
+      alt_int_name: null,
+      city: 'Helsinki',
+      country: 'Finland',
+      state: null,
+      state_code: null,
+    } as Museum
+
+    const editMuseumRequest = jest.fn().mockReturnValue({
+      unwrap: jest.fn(() => Promise.resolve({ museum: createdMuseum.museum })),
+    })
+
+    const refetchMuseums = jest.fn(() => Promise.resolve({ data: [createdMuseum] }))
+
+    mockUseEditMuseumMutation.mockReturnValue([editMuseumRequest, { isLoading: false }] as never)
+    mockUseGetAllMuseumsQuery.mockReturnValue({
+      data: [],
+      isError: false,
+      refetch: refetchMuseums,
+    } as never)
+
+    mockUseDetailContext.mockReturnValue({
+      mode: modeOptionToMode.edit,
+      editData: { lid: 123, now_mus: [] },
+      setEditData,
+    } as never)
+
+    render(<MuseumTab />)
+
+    fireEvent.change(screen.getByLabelText('Institution'), { target: { value: createdMuseum.institution } })
+    fireEvent.change(screen.getByLabelText('Alt. name'), { target: { value: '' } })
+    fireEvent.change(screen.getByLabelText('City'), { target: { value: createdMuseum.city } })
+    fireEvent.change(screen.getByLabelText('Country'), { target: { value: createdMuseum.country } })
+    fireEvent.change(screen.getByLabelText('State'), { target: { value: '' } })
+    fireEvent.change(screen.getByLabelText('State code'), { target: { value: '' } })
+    fireEvent.change(screen.getByLabelText('Museum code'), { target: { value: createdMuseum.museum } })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(editMuseumRequest).toHaveBeenCalled()
+    })
+
+    await waitFor(() => {
+      expect(setEditData).toHaveBeenCalledWith({
+        lid: 123,
+        now_mus: [
+          {
+            lid: 123,
+            museum: createdMuseum.museum,
+            com_mlist: createdMuseum,
+            rowState: 'new',
+          },
+        ],
+      })
+    })
+
+    expect(refetchMuseums).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- add locality-side museum create flow and link into locality edit data
- add unit coverage for the create-museum modal flow
- add museum-focused Cypress coverage for list/create/edit/link flows

## Why
- ensure locality users can create and link museums in one flow
- cover museum CRUD and locality linkage in e2e to prevent regressions

## Validation
- `npm run lint` (via pre-commit)
- `npm run tsc` (via pre-commit)
- `npm run lint:cypress`
- `npx cypress run --spec cypress/e2e/museum.cy.js` (failed to start in this environment: Cypress binary args `--no-sandbox/--smoke-test/--ping`)
