### PR TITLE
[codex] Fix species locality privacy display

### DIFF
--- a/backend/src/routes/species.ts
+++ b/backend/src/routes/species.ts
@@ -19,7 +19,7 @@ router.get('/synonyms', async (_req, res) => {
 
 router.get('/:id', async (req, res) => {
   const id = parseInt(req.params.id)
-  const species = await getSpeciesDetails(id)
+  const species = await getSpeciesDetails(id, req.user)
   if (!species) return res.status(404).send()
   return res.status(200).send(species)
 })

--- a/backend/src/services/species.ts
+++ b/backend/src/services/species.ts
@@ -1,4 +1,4 @@
-import { EditDataType, EditMetaData, SpeciesDetailsType } from '../../../frontend/src/shared/types'
+import { EditDataType, EditMetaData, Role, SpeciesDetailsType, User } from '../../../frontend/src/shared/types'
 import { validateSpecies } from '../../../frontend/src/shared/validators/species'
 import { ValidationObject, referenceValidator } from '../../../frontend/src/shared/validators/validator'
 import Prisma from '../../prisma/generated/now_test_client'
@@ -6,6 +6,7 @@ import { fixBigInt } from '../utils/common'
 import { logDb, nowDb } from '../utils/db'
 import { getReferenceDetails } from './reference'
 import { buildPersonLookupByInitials, getPersonDisplayName, getPersonFromLookup } from './utils/person'
+import { getIdsOfUsersProjects } from './locality'
 
 const TAXONOMIC_FIELDS: Array<keyof Prisma.com_species> = ['genus_name', 'species_name', 'unique_identifier']
 
@@ -111,13 +112,50 @@ export const getAllSpecies = async () => {
   return result
 }
 
-export const getSpeciesDetails = async (id: number) => {
+const filterSpeciesLocalitiesByUser = async (
+  localities: SpeciesDetailsType['now_ls'],
+  user?: User
+): Promise<SpeciesDetailsType['now_ls']> => {
+  if (user && [Role.Admin, Role.EditUnrestricted].includes(user.role)) {
+    return localities
+  }
+
+  if (!user) {
+    return localities.filter(locality => locality.now_loc?.loc_status === false)
+  }
+
+  const usersProjects = await getIdsOfUsersProjects(user)
+
+  return localities.filter(locality => {
+    const nowLoc = locality.now_loc as Prisma.now_loc & { now_plr?: Array<{ pid: number }> }
+    if (!nowLoc) return false
+    if (!nowLoc.loc_status) return true
+    return (nowLoc.now_plr ?? []).some(project => usersProjects.has(project.pid))
+  })
+}
+
+const stripLocalityProjectLinks = (localities: SpeciesDetailsType['now_ls']) =>
+  localities.map(locality => {
+    if (!locality.now_loc) return locality
+    const { now_plr, ...rest } = locality.now_loc as Prisma.now_loc & { now_plr?: Array<{ pid: number }> }
+    return { ...locality, now_loc: rest }
+  })
+
+export const getSpeciesDetails = async (id: number, user?: User) => {
   const result = await nowDb.com_species.findUnique({
     where: { species_id: id },
     include: {
       now_ls: {
         include: {
-          now_loc: true,
+          now_loc: {
+            include: {
+              now_plr: {
+                select: {
+                  pid: true,
+                },
+              },
+            },
+          },
         },
       },
       now_sau: {
@@ -163,7 +201,12 @@ export const getSpeciesDetails = async (id: number) => {
     }
   })
 
-  return JSON.parse(fixBigInt({ ...result, com_taxa_synonym: synonyms || [] })!) as SpeciesDetailsType
+  const filteredLocalities = await filterSpeciesLocalitiesByUser(result.now_ls as SpeciesDetailsType['now_ls'], user)
+  const sanitizedLocalities = stripLocalityProjectLinks(filteredLocalities)
+
+  return JSON.parse(
+    fixBigInt({ ...result, now_ls: sanitizedLocalities, com_taxa_synonym: synonyms || [] })!
+  ) as SpeciesDetailsType
 }
 
 export const getAllSynonyms = async () => {

--- a/backend/src/services/write/species.ts
+++ b/backend/src/services/write/species.ts
@@ -47,7 +47,7 @@ export const writeSpecies = async (
 }
 
 export const deleteSpecies = async (species_id: number, user: User) => {
-  const species = (await getSpeciesDetails(species_id)) as EditDataType<FixBigInt<SpeciesDetailsType>>
+  const species = (await getSpeciesDetails(species_id, user)) as EditDataType<FixBigInt<SpeciesDetailsType>>
   if (!species) throw new Error('Species not found')
 
   const writeHandler = getSpeciesWriteHandler('delete')

--- a/backend/src/unit-tests/species/getSpeciesDetails.test.ts
+++ b/backend/src/unit-tests/species/getSpeciesDetails.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals'
+import { getSpeciesDetails } from '../../services/species'
+import { Role, User } from '../../../../frontend/src/shared/types'
+import { nowDb, logDb } from '../../utils/db'
+import Prisma from '../../../prisma/generated/now_test_client'
+
+jest.mock('../../utils/db', () => ({
+  nowDb: {
+    com_species: { findUnique: jest.fn() },
+    com_taxa_synonym: { findMany: jest.fn() },
+    now_proj_people: { findMany: jest.fn() },
+  },
+  logDb: {
+    log: { findMany: jest.fn() },
+  },
+}))
+
+const mockedNowDb = jest.mocked(nowDb)
+const mockedLogDb = jest.mocked(logDb)
+
+const buildSpeciesResult = (nowLs: Prisma.now_ls[]) =>
+  ({
+    species_id: 1,
+    now_ls: nowLs,
+    now_sau: [],
+  }) as unknown as Awaited<ReturnType<typeof nowDb.com_species.findUnique>>
+
+const makeLocalityRow = (options: {
+  lid: number
+  loc_status: boolean | null
+  projectIds?: number[]
+}): Prisma.now_ls => {
+  return {
+    lid: options.lid,
+    species_id: 1,
+    now_loc: {
+      lid: options.lid,
+      loc_status: options.loc_status,
+      now_plr: (options.projectIds ?? []).map(pid => ({ pid })),
+    },
+  } as unknown as Prisma.now_ls
+}
+
+describe('getSpeciesDetails', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('filters restricted localities for guests', async () => {
+    const publicLocality = makeLocalityRow({ lid: 10, loc_status: false })
+    const restrictedLocality = makeLocalityRow({ lid: 20, loc_status: true, projectIds: [99] })
+
+    mockedNowDb.com_species.findUnique.mockResolvedValue(buildSpeciesResult([publicLocality, restrictedLocality]))
+    mockedNowDb.com_taxa_synonym.findMany.mockResolvedValue([])
+    mockedLogDb.log.findMany.mockResolvedValue([])
+
+    const result = await getSpeciesDetails(1)
+
+    expect(result).toBeTruthy()
+    expect(result?.now_ls).toHaveLength(1)
+    expect(result?.now_ls[0]?.lid).toBe(10)
+    expect((result?.now_ls[0]?.now_loc as { now_plr?: unknown }).now_plr).toBeUndefined()
+  })
+
+  it('includes restricted localities for users with matching projects', async () => {
+    const publicLocality = makeLocalityRow({ lid: 10, loc_status: false })
+    const restrictedLocality = makeLocalityRow({ lid: 20, loc_status: true, projectIds: [42] })
+
+    mockedNowDb.com_species.findUnique.mockResolvedValue(buildSpeciesResult([publicLocality, restrictedLocality]))
+    mockedNowDb.com_taxa_synonym.findMany.mockResolvedValue([])
+    mockedLogDb.log.findMany.mockResolvedValue([])
+    mockedNowDb.now_proj_people.findMany.mockResolvedValue([{ pid: 42, initials: 'AB' }])
+
+    const user: User = { username: 'test', role: Role.EditRestricted, userId: 1, initials: 'AB' }
+
+    const result = await getSpeciesDetails(1, user)
+
+    expect(result).toBeTruthy()
+    expect(result?.now_ls).toHaveLength(2)
+    expect((result?.now_ls[1]?.now_loc as { now_plr?: unknown }).now_plr).toBeUndefined()
+  })
+})

--- a/frontend/src/components/DetailView/common/EditableTable.tsx
+++ b/frontend/src/components/DetailView/common/EditableTable.tsx
@@ -33,6 +33,7 @@ export const EditableTable = <
   idFieldName,
   url,
   getDetailPath,
+  checkRowRestriction,
 }: {
   tableData?: Array<T> | null
   editTableData?: Array<EditDataType<T>> | null
@@ -45,6 +46,7 @@ export const EditableTable = <
   idFieldName?: keyof T
   url?: string
   getDetailPath?: (row: T) => string
+  checkRowRestriction?: (row: T) => boolean
 }) => {
   const { editData, setEditData, mode, data, validator, fieldsWithErrors, setFieldsWithErrors } =
     useDetailContext<ParentType>()
@@ -124,7 +126,8 @@ export const EditableTable = <
   }
 
   const linkToDetails = ({ row }: { row: MRT_Row<T> }) => {
-    if (idFieldName && url) return <ActionComponent {...{ row, idFieldName, url, getDetailPath }} />
+    if (idFieldName && url)
+      return <ActionComponent {...{ row, idFieldName, url, getDetailPath, checkRowRestriction }} />
     return null // code shouldn't get here!
   }
 

--- a/frontend/src/components/Species/Tabs/LocalitySpeciesTab.tsx
+++ b/frontend/src/components/Species/Tabs/LocalitySpeciesTab.tsx
@@ -223,6 +223,7 @@ export const LocalitySpeciesTab = () => {
         idFieldName="lid"
         url="occurrence"
         getDetailPath={row => `/occurrence/${row.lid}/${row.species_id}`}
+        checkRowRestriction={row => Boolean(row.now_loc?.loc_status)}
       />
     </Grouped>
   )

--- a/frontend/src/components/Species/Tabs/LocalityTab.tsx
+++ b/frontend/src/components/Species/Tabs/LocalityTab.tsx
@@ -85,6 +85,7 @@ export const LocalityTab = () => {
         enableAdvancedTableControls={true}
         idFieldName="lid"
         url="locality"
+        checkRowRestriction={row => Boolean((row as { now_loc?: { loc_status?: boolean | null } }).now_loc?.loc_status)}
       />
     </Grouped>
   )


### PR DESCRIPTION
## Summary
- filter species detail localities by user/project visibility to prevent restricted leakage
- surface restricted-locality Policy icon in species Localities and Occurrences tabs
- add unit coverage for species detail filtering

## Why
Species detail tabs were showing private localities to unauthorized users and missing the restriction indicator, which violates locality visibility rules.

## Impact
Unauthorized users only see public (or project-authorized) localities in species detail tabs, and restricted entries show the Policy icon when visible.

## Root Cause
Species detail API returned `now_ls` rows without applying locality visibility rules, and read-only detail tables didn’t pass restriction checks to row actions.

## Testing
- `cd backend && npm run test:unit -- --runTestsByPath src/unit-tests/species/getSpeciesDetails.test.ts`
- `npm run lint:frontend`
- `npm run lint` (pre-commit hook)
- `npm run tsc` (pre-commit hook)
