### PR TITLE
[codex] Remove details icon; row-click navigation in tables

### DIFF
--- a/cypress/e2e/museum.cy.js
+++ b/cypress/e2e/museum.cy.js
@@ -19,7 +19,7 @@ const openMuseumFromList = (institution, code) => {
     .should('be.visible')
     .closest('tr')
     .within(() => {
-      cy.get(`[data-cy="details-button-${code}"]`).click()
+      cy.get(`[data-cy="table-row-${code}"]`).click()
     })
 }
 
@@ -103,10 +103,6 @@ describe('Museum e2e flows', () => {
     cy.get('[aria-label="Filter by Institution"]').type(seedMuseum.institution)
     cy.contains(seedMuseum.institution, { timeout: 10000 })
       .should('be.visible')
-      .closest('tr')
-      .within(() => {
-        cy.get(`[data-cy="details-button-${seedMuseum.code}"]`).should('be.visible')
-      })
   })
 
   it('creates a new museum and lands on its details view', () => {

--- a/cypress/e2e/museum.cy.js
+++ b/cypress/e2e/museum.cy.js
@@ -17,10 +17,8 @@ const openMuseumFromList = (institution, code) => {
   cy.get('[aria-label="Filter by Institution"]').type(institution)
   cy.contains(institution, { timeout: 10000 })
     .should('be.visible')
-    .closest('tr')
-    .within(() => {
-      cy.get(`[data-cy="table-row-${code}"]`).click()
-    })
+    .closest(`[data-cy="table-row-${code}"]`)
+    .click()
 }
 
 const fillMuseumForm = ({ code, institution, city, country, altName, state, stateCode }) => {

--- a/cypress/e2e/ui.cy.js
+++ b/cypress/e2e/ui.cy.js
@@ -59,8 +59,7 @@ describe('Button Tests', () => {
 
   it('Link to species details from species tab', () => {
     cy.visit('/species')
-    // Click the button with the SVG icon
-    cy.get('[data-testid="ManageSearchIcon"]').first().click()
+    cy.get('tbody tr', { timeout: 10000 }).first().click()
     cy.contains('Taxonomy').should('be.visible')
     cy.contains('Synonyms').should('be.visible')
     cy.contains('Diet').should('be.visible')
@@ -75,13 +74,13 @@ describe('Button Tests', () => {
   it('Links between localities and species work', () => {
     cy.visit('/locality/21050')
     cy.get('[role=tablist]').contains('Species').click()
-    cy.get('[data-cy="details-button-21426"]').click()
+    cy.get('[data-cy="table-row-21426"]', { timeout: 10000 }).click()
     cy.url().should('contain', '/species/21426')
     cy.contains('Amblycoptus indet.')
     cy.contains('Mammalia')
     cy.contains('Diet')
     cy.get('[role=tablist]').contains('Localities').click()
-    cy.get('[data-cy="details-button-21050"]').click()
+    cy.get('[data-cy="table-row-21050"]', { timeout: 10000 }).click()
     cy.url().should('contain', '/locality/21050')
     cy.contains('Dmanisi')
     cy.contains('Dating method')

--- a/cypress/e2e/userRights.cy.js
+++ b/cypress/e2e/userRights.cy.js
@@ -18,7 +18,7 @@ describe('Broadly test what different user rights see', () => {
     it('Regions view shows correctly', () => {
       cy.visit('/region')
       cy.contains('region 4452477e')
-      cy.get('[data-cy="details-button-1"]').first().click()
+      cy.get('[data-cy="table-row-1"]', { timeout: 10000 }).first().click()
       cy.contains('Regional Coordinators')
       cy.contains('prs')
       cy.get('[id="edit-button"]').should('exist')
@@ -28,7 +28,7 @@ describe('Broadly test what different user rights see', () => {
     it('Projects view shows correctly', () => {
       cy.visit('/project')
       cy.contains('Workgroup on Insectivores')
-      cy.get('[data-cy="details-button-3"]').first().click()
+      cy.get('[data-cy="table-row-3"]', { timeout: 10000 }).first().click()
       cy.contains('Coordinator')
       cy.contains('NOW Database')
       cy.get('[id="edit-button"]').should('exist')
@@ -38,7 +38,7 @@ describe('Broadly test what different user rights see', () => {
     it('Time Bound view shows correctly', () => {
       cy.visit('/time-bound')
       cy.contains('C2N-y')
-      cy.get('[data-cy="details-button-11"]').first().click()
+      cy.get('[data-cy="table-row-11"]', { timeout: 10000 }).first().click()
       cy.contains('Bound')
       cy.contains('1.778')
       cy.get('[id="edit-button"]').should('exist')

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -32,7 +32,7 @@ Cypress.Commands.overwrite('visit', (originalFn, url, options) => {
 
   return cy
     .task('waitForAppHealthy', { url: baseUrl }, { timeout: appWaitTimeoutMs })
-    .then(() => {
+    .then({ timeout: appWaitTimeoutMs }, () => {
       return originalFn(url, options)
     })
 })

--- a/frontend/src/components/DetailView/common/EditableTable.tsx
+++ b/frontend/src/components/DetailView/common/EditableTable.tsx
@@ -1,14 +1,14 @@
 import { EditDataType, RowState } from '@/shared/types'
-import { CircularProgress, Box, Button } from '@mui/material'
+import { CircularProgress, Box, Button, Tooltip } from '@mui/material'
 import { type MRT_ColumnDef, type MRT_Row, type MRT_RowData } from 'material-react-table'
 import { useDetailContext } from '../Context/DetailContext'
 import RemoveCircleOutlineIcon from '@mui/icons-material/RemoveCircleOutline'
 import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline'
+import PolicyIcon from '@mui/icons-material/Policy'
 import { useEffect } from 'react'
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom'
 import { usePageContext } from '@/components/Page'
 import { checkFieldErrors } from './checkFieldErrors'
-import { ActionComponent } from '@/components/TableView/ActionComponent'
 import { DetailTabTable } from './DetailTabTable'
 
 const getNewState = (state: RowState): RowState => {
@@ -125,20 +125,18 @@ export const EditableTable = <
     return `/${url}/${String(row[idFieldName as keyof T] ?? '')}`
   }
 
-  const linkToDetails = ({ row }: { row: MRT_Row<T> }) => {
-    if (idFieldName && url)
-      return <ActionComponent {...{ row, idFieldName, url, getDetailPath, checkRowRestriction }} />
-    return null // code shouldn't get here!
+  const restrictionIndicator = ({ row }: { row: MRT_Row<T> }) => {
+    if (!checkRowRestriction || !checkRowRestriction(row.original)) return null
+
+    return (
+      <Tooltip placement="top" title="This item has restricted visibility">
+        <PolicyIcon aria-label="Restricted visibility indicator" color="primary" fontSize="medium" />
+      </Tooltip>
+    )
   }
 
   const resolveRenderRowActions = () => {
-    if (mode.read && (!idFieldName || !url)) {
-      return undefined
-    }
-
-    if (mode.read && idFieldName && url) {
-      return linkToDetails
-    }
+    if (mode.read) return checkRowRestriction ? restrictionIndicator : undefined
 
     return actionRow
   }
@@ -172,11 +170,11 @@ export const EditableTable = <
       enableTopToolbar={enableAdvancedTableControls}
       enableColumnActions={enableAdvancedTableControls}
       enableSorting={enableAdvancedTableControls}
-      enableRowActions={Boolean(resolveRenderRowActions())}
+      enableRowActions={!mode.read || Boolean(checkRowRestriction)}
       renderRowActions={resolveRenderRowActions()}
       muiTableBodyRowProps={({ row }: { row: MRT_Row<T> }) => ({
         onClick: () => {
-          if (mode.read && idFieldName && url && getDetailPath) {
+          if (mode.read && idFieldName && url) {
             setPreviousTableUrls([...previousTableUrls, `${location.pathname}?tab=${searchParams.get('tab')}`])
             navigate(resolveDetailPath(row.original), {
               state: { returnTo: `${location.pathname}${location.search}` },
@@ -185,7 +183,7 @@ export const EditableTable = <
         },
         sx: {
           backgroundColor: rowStateToColor(row.original.rowState),
-          cursor: mode.read && idFieldName && url && getDetailPath ? 'pointer' : undefined,
+          cursor: mode.read && idFieldName && url ? 'pointer' : undefined,
         },
       })}
     />

--- a/frontend/src/components/DetailView/common/EditableTable.tsx
+++ b/frontend/src/components/DetailView/common/EditableTable.tsx
@@ -173,6 +173,7 @@ export const EditableTable = <
       enableRowActions={!mode.read || Boolean(checkRowRestriction)}
       renderRowActions={resolveRenderRowActions()}
       muiTableBodyRowProps={({ row }: { row: MRT_Row<T> }) => ({
+        'data-cy': idFieldName ? `table-row-${String(row.original[idFieldName])}` : undefined,
         onClick: () => {
           if (mode.read && idFieldName && url) {
             setPreviousTableUrls([...previousTableUrls, `${location.pathname}?tab=${searchParams.get('tab')}`])

--- a/frontend/src/components/DetailView/common/tabLayoutHelpers.tsx
+++ b/frontend/src/components/DetailView/common/tabLayoutHelpers.tsx
@@ -14,7 +14,7 @@ export const ArrayToTable = ({ array, half }: { array: Array<Array<ReactNode>>; 
   return (
     <Grid container direction="column">
       {array.map((row, rowIndex) => (
-        <Grid key={rowIndex} container direction="row" size={12} minHeight="2.5em">
+        <Grid key={rowIndex} container direction="row" size={12} minHeight="2.5em" alignItems="stretch">
           {row.map((item, index) => (
             <Grid
               key={index}
@@ -23,7 +23,7 @@ export const ArrayToTable = ({ array, half }: { array: Array<Array<ReactNode>>; 
                 display: 'flex',
                 alignItems: 'center',
                 justifyContent: 'left',
-                height: '100%',
+                minHeight: '2.5em',
                 borderBottom: '1px solid rgba(224, 224, 224, 1)',
                 borderRight: '1px solid rgba(224, 224, 224, 1)',
               }}

--- a/frontend/src/components/TableView/TableView.tsx
+++ b/frontend/src/components/TableView/TableView.tsx
@@ -220,6 +220,7 @@ export const TableView = <T extends MRT_RowData>({
   }
 
   const muiTableBodyRowProps = ({ row }: { row: MRT_Row<T> }) => ({
+    'data-cy': `table-row-${String(row.original[idFieldName])}`,
     onClick: () => {
       const sanitizedFilters = sanitizeColumnFilters(columnFilters)
       const columnFilterToUrl = `columnfilters=${JSON.stringify(sanitizedFilters)}`

--- a/frontend/src/components/TableView/TableView.tsx
+++ b/frontend/src/components/TableView/TableView.tsx
@@ -12,7 +12,7 @@ import {
   MRT_Row,
   type MRT_FilterFn,
 } from 'material-react-table'
-import { Alert, Box, CircularProgress, IconButton, Paper, Tooltip } from '@mui/material'
+import { Alert, Box, CircularProgress, Paper, Tooltip } from '@mui/material'
 import type { FetchBaseQueryError } from '@reduxjs/toolkit/query'
 import type { SerializedError } from '@reduxjs/toolkit'
 import type { FilterFn } from '@tanstack/table-core'
@@ -25,7 +25,6 @@ import { defaultPagination, defaultPaginationSmall } from '@/common'
 import '../../styles/TableView.css'
 import { TableToolBar } from './TableToolBar'
 import NotListedLocationIcon from '@mui/icons-material/NotListedLocation'
-import ManageSearchIcon from '@mui/icons-material/ManageSearch'
 import PolicyIcon from '@mui/icons-material/Policy'
 import '../../styles/tableview/TableView.css'
 import { resolveErrorMessage, resolveErrorStatus } from './errorUtils'
@@ -259,81 +258,54 @@ export const TableView = <T extends MRT_RowData>({
      * Row action audit (Task T1):
      *
      * • LocalityTable – supplies `selectorFn`, `checkRowRestriction`, and `tableRowAction`.
-     *   Shows the default ManageSearch navigation icon (or Add when `selectorFn` is used),
-     *   renders an "S" synonym action when `row.original.has_synonym` is true, and displays
-     *   the Policy restriction icon when `loc_status` flags a restricted locality.
-     * • SpeciesTable – provides `selectorFn` and `tableRowAction`. Uses the same default
-     *   ManageSearch/Add icon behaviour, an "S" synonym action for `has_synonym`, renders
-     *   optional extras via `renderRowActionExtras` (e.g. the species comment "C" button),
-     *   and the NotListedLocationIcon whenever `row.original.has_no_locality` is true.
+     *   Shows the Add icon when `selectorFn` is used, renders an "S" synonym action when
+     *   `row.original.has_synonym` is true, and displays the Policy restriction icon when
+     *   `loc_status` flags a restricted locality. The details icon is hidden when rows are
+     *   clickable (row click handles navigation).
+     * • SpeciesTable – provides `selectorFn` and `tableRowAction`. Uses the same Add icon
+     *   behaviour, an "S" synonym action for `has_synonym`, renders optional extras via
+     *   `renderRowActionExtras` (e.g. the species comment "C" button), and the
+     *   NotListedLocationIcon whenever `row.original.has_no_locality` is true.
      * • CrossSearchTable – passes `selectorFn` and `checkRowRestriction`, so rows use the
-     *   ManageSearch/Add icon and may show the Policy restriction indicator. No synonym
-     *   action is rendered because the dataset never sets `has_synonym`.
+     *   Add icon and may show the Policy restriction indicator. No synonym action is
+     *   rendered because the dataset never sets `has_synonym`.
      * • SelectingTable (used inside detail modals) – always passes `selectorFn` and may
      *   forward `tableRowAction` (e.g. locality/species synonym modals). This results in
      *   the Add icon for selection plus optional synonym "S" action.
      * • ReferenceTable, MuseumTable, PersonTable, RegionTable, TimeBoundTable,
-     *   TimeUnitTable, ProjectTable, and SequenceTable – rely on the default
-     *   ManageSearch navigation action (or Add when a consumer injects `selectorFn`).
+     *   TimeUnitTable, ProjectTable, and SequenceTable – show the details icon only when
+     *   rows are not clickable (for example, selector modals).
      *
      * Any future layout refactor must preserve these conditional branches because they
      * encode the full set of icons currently surfaced in production.
      */
     renderRowActions: ({ row }) => {
-      const showSynonymIndicator = Boolean(row.original.has_synonym)
+      const showSynonymAction = Boolean(tableRowAction && row.original.has_synonym)
       const showNoLocalityIndicator = Boolean(row.original.has_no_locality)
-
-      const hasCustomDetailPath = Boolean(getDetailPath && !selectorFn && !tableRowAction)
+      const showRestrictionIndicator = Boolean(checkRowRestriction && checkRowRestriction(row.original))
+      const showBaseAction = Boolean(selectorFn) || !clickableRows
 
       return (
         <Box className="row-actions-column">
-          {hasCustomDetailPath ? (
-            <Box display="flex" alignItems="center" gap={0.5}>
-              <Tooltip placement="top" title="View details">
-                <IconButton
-                  aria-label="View details"
-                  data-cy={`details-button-${String(row.original[idFieldName])}`}
-                  onClick={event => {
-                    event.stopPropagation()
-                    const sanitizedFilters = sanitizeColumnFilters(columnFilters)
-                    const columnFilterToUrl = `columnfilters=${JSON.stringify(sanitizedFilters)}`
-                    const sortingToUrl = `sorting=${JSON.stringify(sorting)}`
-                    const paginationToUrl = `pagination=${JSON.stringify(pagination)}`
-                    setPreviousTableUrls([
-                      ...previousTableUrls,
-                      `${location.pathname}?&${columnFilterToUrl}&${sortingToUrl}&${paginationToUrl}`,
-                    ])
-                    navigate(resolveDetailPath(row.original), {
-                      state: { returnTo: `${location.pathname}${location.search}` },
-                    })
-                  }}
-                  size="small"
-                  sx={{ p: 0.5 }}
-                >
-                  <ManageSearchIcon fontSize="small" />
-                </IconButton>
-              </Tooltip>
-              {checkRowRestriction && checkRowRestriction(row.original) && (
-                <Tooltip placement="top" title="This item has restricted visibility">
-                  <PolicyIcon aria-label="Restricted visibility indicator" color="primary" fontSize="medium" />
-                </Tooltip>
-              )}
-            </Box>
-          ) : (
-            <ActionComponent {...{ selectorFn, url, checkRowRestriction, row, idFieldName }} />
-          )}
-          {showSynonymIndicator && (
+          {showBaseAction ? (
             <ActionComponent
               {...{
                 selectorFn,
-                tableRowAction,
                 url,
                 checkRowRestriction,
                 row,
                 idFieldName,
+                getDetailPath,
               }}
             />
+          ) : (
+            showRestrictionIndicator && (
+              <Tooltip placement="top" title="This item has restricted visibility">
+                <PolicyIcon aria-label="Restricted visibility indicator" color="primary" fontSize="medium" />
+              </Tooltip>
+            )
           )}
+          {showSynonymAction && <ActionComponent {...{ tableRowAction, url, row, idFieldName }} />}
           {renderRowActionExtras && renderRowActionExtras({ row })}
           {showNoLocalityIndicator && (
             <Tooltip title="This species is not currently in any locality" placement="right-start">


### PR DESCRIPTION
Fixes #1099.

- Remove the magnifier (View details) action icon from table lists when rows are already clickable for navigation.
- Prevent duplicated action icons in locality/species lists when rows have synonyms.
- Detail-page lists now navigate via row click (including `locality/<id>?tab=...` list tabs) instead of requiring an Actions button.
- Align ArrayFrame table row borders when values are empty (e.g. Basin/Subbasin) for a cleaner layout.

Validation:
- `npm run lint:frontend`
- Pre-commit hooks (lint + tsc) passed on commit.