### PR TITLE
Restrict number textfields to numeric input

### DIFF
--- a/frontend/src/components/DetailView/common/editingComponents.test.tsx
+++ b/frontend/src/components/DetailView/common/editingComponents.test.tsx
@@ -1,8 +1,8 @@
-import { describe, expect, it } from '@jest/globals'
+import { describe, expect, it, jest } from '@jest/globals'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { DetailContext, DetailContextType, modeOptionToMode } from '@/components/DetailView/Context/DetailContext'
-import { BasisForAgeSelection } from './editingComponents'
+import { BasisForAgeSelection, EditableTextField } from './editingComponents'
 import { EditDataType, LocalityDetailsType, TimeUnit } from '@/shared/types'
 import { ReactNode, useState } from 'react'
 import '@testing-library/jest-dom'
@@ -140,5 +140,74 @@ describe('BasisForAgeSelection', () => {
     await waitFor(() => {
       expect(screen.getByTestId('min-age').textContent).toContain('42.5')
     })
+  })
+})
+
+const NumberInputWrapper = ({ handleSetEditData }: { handleSetEditData?: (value: number | string) => void }) => {
+  const initialEditData = { min_age: '' } as unknown as EditDataType<LocalityDetailsType>
+  const [editData, setEditData] = useState<EditDataType<LocalityDetailsType>>(initialEditData)
+
+  const contextValue: DetailContextType<LocalityDetailsType> = {
+    data: initialEditData as unknown as LocalityDetailsType,
+    mode: modeOptionToMode.edit,
+    setMode: () => undefined,
+    editData,
+    setEditData,
+    isDirty: false,
+    resetEditData: () => setEditData(initialEditData),
+    textField: () => <></>,
+    bigTextField: () => <></>,
+    dropdown: () => <></>,
+    dropdownWithSearch: () => <></>,
+    radioSelection: () => <></>,
+    validator: () => ({ name: '', error: null }),
+    fieldsWithErrors: {},
+    setFieldsWithErrors: () => undefined,
+  }
+
+  return (
+    <DetailContext.Provider value={contextValue as DetailContextType<unknown>}>
+      <div data-testid="min-age">{String(editData.min_age ?? '')}</div>
+      <EditableTextField<LocalityDetailsType> field="min_age" type="number" handleSetEditData={handleSetEditData} />
+    </DetailContext.Provider>
+  )
+}
+
+describe('EditableTextField (number)', () => {
+  it('rejects non-numeric characters like e/E/+ while typing', async () => {
+    const user = userEvent.setup()
+    render(<NumberInputWrapper />)
+
+    const input = screen.getByRole<HTMLInputElement>('spinbutton')
+    await user.type(input, '12e3')
+
+    expect(input.value).toBe('123')
+    expect(screen.getByTestId('min-age').textContent).toBe('123')
+  })
+
+  it('allows negative numbers without setting NaN in editData', async () => {
+    const user = userEvent.setup()
+    render(<NumberInputWrapper />)
+
+    const input = screen.getByRole<HTMLInputElement>('spinbutton')
+    await user.type(input, '-1.5')
+
+    expect(input.value).toBe('-1.5')
+    expect(screen.getByTestId('min-age').textContent).toBe('-1.5')
+  })
+
+  it('calls handleSetEditData only with numbers or empty string', async () => {
+    const user = userEvent.setup()
+    const handleSetEditData = jest.fn()
+
+    render(<NumberInputWrapper handleSetEditData={handleSetEditData} />)
+
+    const input = screen.getByRole<HTMLInputElement>('spinbutton')
+    await user.type(input, '1e2')
+
+    for (const call of handleSetEditData.mock.calls) {
+      const arg = call[0]
+      expect(typeof arg === 'number' || arg === '').toBe(true)
+    }
   })
 })

--- a/frontend/src/components/DetailView/common/editingComponents.tsx
+++ b/frontend/src/components/DetailView/common/editingComponents.tsx
@@ -295,6 +295,19 @@ export const EditableTextField = <T extends object>({
   const errorObject = validator(editData, field)
   const { error } = errorObject
 
+  const [numberInputValue, setNumberInputValue] = useState('')
+
+  useEffect(() => {
+    if (type !== 'number') return
+    const raw = editData[field]
+    if (raw === null || raw === undefined || raw === '') {
+      setNumberInputValue('')
+      return
+    }
+    setNumberInputValue(String(raw))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editData[field], type])
+
   useEffect(() => {
     checkFieldErrors(String(field), errorObject, fieldsWithErrors, setFieldsWithErrors)
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -302,17 +315,37 @@ export const EditableTextField = <T extends object>({
 
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     const value = event?.currentTarget?.value
+    if (type === 'number') {
+      if (value === '') {
+        setNumberInputValue('')
+        if (handleSetEditData) handleSetEditData('')
+        else setEditData({ ...editData, [field]: '' })
+        return
+      }
+
+      if (!isAllowedNumberInputValue(value)) return
+      setNumberInputValue(value)
+
+      const asNumber = Number(value)
+      if (isPartialNumberInputValue(value) || Number.isNaN(asNumber)) return
+
+      if (handleSetEditData) handleSetEditData(asNumber)
+      else setEditData({ ...editData, [field]: asNumber })
+      return
+    }
+
     if (handleSetEditData) {
       handleSetEditData(value)
+      return
+    }
+
+    if (type === 'date') {
+      // For date fields, ensure the value is stored as a string in the format 'YYYY-MM-DD'
+      setEditData({ ...editData, [field]: value })
+    } else if (type === 'text' || value === '') {
+      setEditData({ ...editData, [field]: value })
     } else {
-      if (type === 'date') {
-        // For date fields, ensure the value is stored as a string in the format 'YYYY-MM-DD'
-        setEditData({ ...editData, [field]: value })
-      } else if (type === 'text' || value === '') {
-        setEditData({ ...editData, [field]: value })
-      } else {
-        setEditData({ ...editData, [field]: parseFloat(value) })
-      }
+      setEditData({ ...editData, [field]: parseFloat(value) })
     }
   }
 
@@ -321,12 +354,30 @@ export const EditableTextField = <T extends object>({
     setEditData({ ...editData, [field]: (editData[field] as string).trim() })
   }
 
+  const handleNumberBlur = () => {
+    const value = numberInputValue
+    if (value === '') return
+    if (isPartialNumberInputValue(value)) {
+      setNumberInputValue('')
+      if (handleSetEditData) handleSetEditData('')
+      else setEditData({ ...editData, [field]: '' })
+      return
+    }
+    const asNumber = Number(value)
+    if (Number.isNaN(asNumber)) return
+    setNumberInputValue(String(asNumber))
+  }
+
   const editingComponent = (
     <TextField
       sx={{ width: fieldWidth, backgroundColor: disabled ? 'grey' : '' }}
       onChange={handleChange}
+      onKeyDown={event => {
+        if (type !== 'number') return
+        if (event.key === 'e' || event.key === 'E' || event.key === '+') event.preventDefault()
+      }}
       id={`${String(field)}-textfield`}
-      value={editData[field] ?? ''}
+      value={type === 'number' ? numberInputValue : editData[field] ?? ''}
       variant="outlined"
       size="small"
       error={!!error}
@@ -334,13 +385,20 @@ export const EditableTextField = <T extends object>({
       type={type}
       multiline={big}
       disabled={disabled}
-      onBlur={() => trim && trimValue()}
+      onBlur={() => {
+        if (type === 'number') handleNumberBlur()
+        if (trim) trimValue()
+      }}
       InputProps={readonly ? { readOnly: true } : { readOnly: false }}
     />
   )
 
   return <DataValue<T> field={field} EditElement={editingComponent} round={round} />
 }
+
+const isAllowedNumberInputValue = (value: string) => /^-?\d*(\.\d*)?$/.test(value) || isPartialNumberInputValue(value)
+
+const isPartialNumberInputValue = (value: string) => value === '-' || value === '.' || value === '-.'
 
 export const FieldWithTableSelection = <T extends object, ParentType extends object>({
   targetField,


### PR DESCRIPTION
Refs #715

Prevents entering non-numeric characters (e/E/+) in number fields, and keeps intermediate values (like '-' or '.') in local input state without writing NaN into editData.

Adds tests covering number field behavior.
