### PR TITLE
Validate region coordinator initials

### DIFF
--- a/backend/src/api-tests/region/update.test.ts
+++ b/backend/src/api-tests/region/update.test.ts
@@ -104,6 +104,26 @@ describe('Updating region works', () => {
     expect(invalidCoordinatorResultBody.length).toEqual(1) //There should be 1 validation error
   })
 
+  it('Updating fails when coordinator initials do not exist', async () => {
+    const { body: resultBody, status } = await send('region/', 'PUT', {
+      region: {
+        reg_coord_id: 1,
+        region: 'Updated Region Missing Coordinator',
+        now_reg_coord_people: [{ initials: 'ZZ' }],
+      },
+    })
+
+    expect(status).toEqual(403)
+    expect(resultBody).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'Region Coordinators',
+          error: expect.stringContaining('ZZ'),
+        }),
+      ])
+    )
+  })
+
   it('Updating fails without permissions', async () => {
     logout()
     const { body: resultBodyNoPerm, status: resultStatusNoPerm } = await send('region/', 'PUT', {

--- a/backend/src/routes/region.ts
+++ b/backend/src/routes/region.ts
@@ -23,7 +23,7 @@ router.put(
   requireOneOf([Role.Admin]),
   async (req: Request<object, object, { region: EditDataType<RegionDetails> & EditMetaData }>, res) => {
     const { ...editedRegion } = req.body.region
-    const validationErrors = validateEntireRegion({ ...editedRegion })
+    const validationErrors = await validateEntireRegion({ ...editedRegion })
     if (validationErrors.length > 0) {
       return res.status(403).send(validationErrors)
     }

--- a/backend/src/services/region.ts
+++ b/backend/src/services/region.ts
@@ -1,5 +1,5 @@
 import { nowDb } from '../utils/db'
-import { EditDataType, EditMetaData, RegionDetails } from '../../../frontend/src/shared/types'
+import { EditDataType, EditMetaData, RegionCoordinator, RegionDetails } from '../../../frontend/src/shared/types'
 import { validateRegion } from '../../../frontend/src/shared/validators/region'
 import { ValidationObject } from '../../../frontend/src/shared/validators/validator'
 import Prisma from '../../prisma/generated/now_test_client'
@@ -26,12 +26,49 @@ export const getRegionDetails = async (id: number) => {
   return result
 }
 
-export const validateEntireRegion = (editedFields: EditDataType<Prisma.now_reg_coord> & EditMetaData) => {
+const validateRegionCoordinatorInitialsExist = async (
+  coordinators: EditDataType<RegionCoordinator[]>
+): Promise<ValidationObject | null> => {
+  const uniqueInitials = Array.from(
+    new Set(
+      coordinators
+        .filter(coordinator => coordinator.rowState !== 'removed' && coordinator.rowState !== 'cancelled')
+        .map(coordinator => (typeof coordinator.initials === 'string' ? coordinator.initials.trim() : ''))
+        .filter(Boolean)
+    )
+  )
+
+  if (uniqueInitials.length === 0) return null
+
+  const existingPeople = await nowDb.com_people.findMany({
+    where: { initials: { in: uniqueInitials } },
+    select: { initials: true },
+  })
+  const existingInitials = new Set(existingPeople.map(p => p.initials))
+
+  const missing = uniqueInitials.filter(initials => !existingInitials.has(initials))
+  if (missing.length === 0) return null
+
+  return {
+    name: 'Region Coordinators',
+    error: `Coordinator initials not found: ${missing.join(', ')}`,
+  }
+}
+
+export const validateEntireRegion = async (editedFields: EditDataType<Prisma.now_reg_coord> & EditMetaData) => {
   const keys = Object.keys(editedFields)
   const errors: ValidationObject[] = []
   for (const key of keys) {
     const error = validateRegion(editedFields as EditDataType<RegionDetails>, key as keyof RegionDetails)
     if (error.error) errors.push(error)
   }
+
+  if ('now_reg_coord_people' in editedFields && editedFields.now_reg_coord_people) {
+    const coordinatorError = await validateRegionCoordinatorInitialsExist(
+      editedFields.now_reg_coord_people as EditDataType<RegionCoordinator[]>
+    )
+    if (coordinatorError) errors.push(coordinatorError)
+  }
+
   return errors
 }


### PR DESCRIPTION
Refs #661

Adds server-side validation for `now_reg_coord_people[].initials` so nonexistent coordinator initials return a 403 validation error instead of an internal server error.

Includes an API test for the missing-coordinator case.
