### PR TITLE
Reset table page index on filter/sort changes

### DIFF
--- a/frontend/src/components/TableView/TableView.tsx
+++ b/frontend/src/components/TableView/TableView.tsx
@@ -341,7 +341,7 @@ export const TableView = <T extends MRT_RowData>({
     manualPagination: serverSidePagination,
     manualSorting: serverSidePagination,
     rowCount: rowCount,
-    autoResetPageIndex: false,
+    autoResetPageIndex: true,
     positionPagination: paginationPlacement ?? (selectorFn ? 'top' : 'both'),
     paginationDisplayMode: 'pages',
     muiTablePaperProps: {


### PR DESCRIPTION
Refs #943

Sets `autoResetPageIndex` to `true` for `TableView` so changing filters/sorting resets pagination to page 1, avoiding empty pages when result counts shrink.
