### PR TITLE
Front-page changelog from GitHub releases

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -21,6 +21,7 @@ import userRouter from './routes/user'
 import emailRouter, { emailLimiter } from './routes/email'
 import versionRouter from './routes/version'
 import geonamesRouter from './routes/geonames-api'
+import changelogRouter from './routes/changelog'
 import { responseLogger } from './middlewares/requestLogger'
 import compression from 'compression'
 import { ENABLE_WRITE, RUNNING_ENV } from './utils/config'
@@ -72,6 +73,7 @@ app.use('/sedimentary-structure', sedimentaryStructureRouter)
 app.use('/collecting-method-values', collectingMethodValuesRouter)
 app.use('/email', emailRouter)
 app.use('/version', versionRouter)
+app.use('/changelog', changelogRouter)
 app.use('/geonames-api', geonamesRouter)
 if (RUNNING_ENV === 'dev') app.use('/test', testRouter)
 

--- a/backend/src/routes/changelog.ts
+++ b/backend/src/routes/changelog.ts
@@ -1,0 +1,11 @@
+import { Router } from 'express'
+import { getChangelog } from '../services/changelog'
+
+const router = Router()
+
+router.get('/', async (_req, res) => {
+  const changelog = await getChangelog()
+  return res.status(200).send(changelog)
+})
+
+export default router

--- a/backend/src/services/changelog.ts
+++ b/backend/src/services/changelog.ts
@@ -1,0 +1,69 @@
+export type ChangelogEntry = {
+  name: string
+  tagName: string
+  createdAt: string
+  url: string
+  bodyHtml: string
+}
+
+type GithubRelease = {
+  name: string | null
+  tag_name: string
+  created_at: string
+  html_url: string
+  body_html: string
+}
+
+const CACHE_TTL_MS = 15 * 60 * 1000
+
+let cached: { value: ChangelogEntry[]; fetchedAt: number } | null = null
+
+const getGithubAuthHeader = () => {
+  const token = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN
+  return token ? `Bearer ${token}` : null
+}
+
+const stripInternalSection = (bodyHtml: string) => {
+  const internalHeading = /<h3>\s*Internal\s*<\/h3>/i
+  const index = bodyHtml.search(internalHeading)
+  if (index === -1) return bodyHtml
+  return bodyHtml.slice(0, index)
+}
+
+const isInternalRelease = (name: string) => name.trim().toLowerCase().startsWith('internal:')
+
+export const getChangelog = async (): Promise<ChangelogEntry[]> => {
+  if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) return cached.value
+
+  const authHeader = getGithubAuthHeader()
+  const headers: Record<string, string> = {
+    Accept: 'application/vnd.github.v3.html+json',
+    'User-Agent': 'nowdatabase-backend',
+  }
+  if (authHeader) headers.Authorization = authHeader
+
+  const response = await fetch('https://api.github.com/repos/nowcommunity/nowdatabase/releases?per_page=10', {
+    headers,
+  })
+
+  if (!response.ok) {
+    if (cached) return cached.value
+    throw new Error(`Failed to fetch releases: ${response.status}`)
+  }
+
+  const releases = (await response.json()) as GithubRelease[]
+
+  const entries = releases
+    .filter(release => typeof release.name === 'string' && release.name.trim().length > 0)
+    .filter(release => !isInternalRelease(release.name!))
+    .map(release => ({
+      name: release.name!,
+      tagName: release.tag_name,
+      createdAt: release.created_at,
+      url: release.html_url,
+      bodyHtml: stripInternalSection(release.body_html ?? ''),
+    }))
+
+  cached = { value: entries, fetchedAt: Date.now() }
+  return entries
+}

--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -20,3 +20,4 @@
 - Added backend validation for tab-list query params (`sorting`, `pagination`, `limit/offset`, `columnfilters`) with structured `400` errors on invalid inputs for Reference, Time Unit, Time Bound, and Museum detail-tab endpoints.
 - Added tab-list API integration coverage for invalid sorting/filter payloads and pagination behavior, plus read-only Project tab unit coverage that verifies edit-only controls stay hidden without edit rights.
 - Added rollout documentation for unified `DetailTabTable` behavior, migration checklist, and known server/client filtering constraints.
+- Added a front-page changelog sourced from GitHub releases via `GET /changelog` (see `documentation/functionality/changelog.md`).

--- a/documentation/functionality/changelog.md
+++ b/documentation/functionality/changelog.md
@@ -1,0 +1,50 @@
+# In-app Changelog (GitHub Releases)
+
+The application front page shows a **Changelog** section that is sourced from **GitHub releases** in the
+`nowcommunity/nowdatabase` repository.
+
+## Overview
+
+- Backend route: `GET /changelog`
+- Frontend: `frontend/src/components/FrontPage.tsx` fetches the route via RTK Query and renders the entries.
+- Purpose: show what has been deployed (release title + description + release creation time).
+
+## Backend
+
+### Route
+
+- `backend/src/routes/changelog.ts` exposes `GET /changelog`
+- `backend/src/services/changelog.ts` fetches GitHub releases from the GitHub REST API.
+
+### Caching and failure behavior
+
+- The backend keeps an in-memory cache with a TTL (see `CACHE_TTL_MS` in `backend/src/services/changelog.ts`).
+- If GitHub fetching fails and there is a cached value, the cached value is returned.
+
+### Authentication / rate limits
+
+- The service will use `process.env.GITHUB_TOKEN` (or `process.env.GH_TOKEN`) if present.
+- If no token is provided, unauthenticated GitHub API requests are used and may hit stricter rate limits.
+
+## Frontend
+
+- Query is defined in `frontend/src/redux/changelogReducer.ts` and hits `/changelog`.
+- The front page renders `bodyHtml` using `dangerouslySetInnerHTML`.
+  - The HTML comes from GitHub’s `application/vnd.github.v3.html+json` response format.
+  - GitHub’s rendered HTML is expected to be sanitized by GitHub; we do not add extra client-side sanitization.
+
+## Filtering “internal” notes
+
+The changelog supports a simple mechanism to hide internal-only notes:
+
+- A release is omitted entirely if its **title** starts with `Internal:`
+- Within a release description, anything after a heading `### Internal` is omitted.
+
+## How to publish a changelog entry
+
+1. Create a GitHub release in `nowcommunity/nowdatabase`.
+2. Write user-facing notes in the release title/body.
+3. Optionally include internal-only notes:
+   - Prefix the release title with `Internal:` to hide the whole release, or
+   - Add a `### Internal` section at the end of the release body to hide only that section.
+

--- a/frontend/src/components/FrontPage.tsx
+++ b/frontend/src/components/FrontPage.tsx
@@ -10,6 +10,7 @@ import mapSvg from '../resource/map.svg'
 import logo from '../resource/nowlogo.jpg'
 import '../styles/FrontPage.css'
 import { occurrenceLabels } from '@/constants/occurrenceLabels'
+import { useGetChangelogQuery } from '@/redux/changelogReducer'
 
 export const FrontPage = () => {
   const mapContainerRef = useRef<HTMLDivElement | null>(null)
@@ -18,6 +19,7 @@ export const FrontPage = () => {
     useGetSpeciesStatisticsQuery()
   const { data: localityStatisticsQueryData, isFetching: localityStatisticsQueryIsFetching } =
     useGetLocalityStatisticsQuery()
+  const { data: changelogData } = useGetChangelogQuery()
 
   // Map hover effect
   useEffect(() => {
@@ -148,6 +150,33 @@ export const FrontPage = () => {
           </p>
           <h3>DOI</h3>
           <a href="http://doi.org/10.5281/zenodo.4268068">doi:10.5281/zenodo.4268068</a>.
+        </div>
+        <div>
+          <h2>Changelog</h2>
+          <div className="activity-stats">
+            <div className="stat-table" style={{ width: '100%' }}>
+              {!changelogData || changelogData.length === 0 ? (
+                <p>No recent releases.</p>
+              ) : (
+                changelogData.map(entry => (
+                  <div key={entry.tagName} style={{ marginBottom: '1.5em' }}>
+                    <h3 style={{ marginBottom: '0.25em' }}>
+                      <a href={entry.url} target="_blank" rel="noreferrer">
+                        {entry.name}
+                      </a>
+                    </h3>
+                    <div style={{ fontSize: 14, opacity: 0.75, marginBottom: '0.5em' }}>
+                      {new Date(entry.createdAt).toLocaleString('fi-FI')}
+                    </div>
+                    <div
+                      style={{ fontSize: 14, overflowWrap: 'anywhere' }}
+                      dangerouslySetInnerHTML={{ __html: entry.bodyHtml }}
+                    />
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
         </div>
       </section>
     </main>

--- a/frontend/src/redux/changelogReducer.ts
+++ b/frontend/src/redux/changelogReducer.ts
@@ -1,0 +1,19 @@
+import { api } from './api'
+
+export type ChangelogEntry = {
+  name: string
+  tagName: string
+  createdAt: string
+  url: string
+  bodyHtml: string
+}
+
+const changelogApi = api.injectEndpoints({
+  endpoints: builder => ({
+    getChangelog: builder.query<ChangelogEntry[], void>({
+      query: () => ({ url: '/changelog' }),
+    }),
+  }),
+})
+
+export const { useGetChangelogQuery } = changelogApi


### PR DESCRIPTION
Refs #127

Implements a simple front-page changelog based on GitHub releases:
- Backend `GET /changelog` fetches recent releases (cached in-memory) using the GitHub API (html+json) and filters out Internal releases/sections.
- Frontend `FrontPage` renders the entries.

Filtering:
- Release omitted if title starts with `Internal:`
- Description omitted from the `### Internal` heading onward.
