### PR TITLE
Export tooltip: mention hidden columns

### DIFF
--- a/frontend/src/components/TableView/TableToolBar.tsx
+++ b/frontend/src/components/TableView/TableToolBar.tsx
@@ -62,7 +62,7 @@ export const TableToolBar = <T extends MRT_RowData>({
       )}
       <Box className="icon-buttons">
         <MRT_ShowHideColumnsButton table={table} />
-        <Tooltip title="Export">
+        <Tooltip title="Export table (hide columns to exclude them)">
           <IconButton
             id="export-button"
             aria-controls={open ? 'export-menu' : undefined}


### PR DESCRIPTION
Refs #230\n\nUpdates the Export button tooltip to clarify that only visible columns are included in exports (hide columns to exclude them).