### PR TITLE
Detail tab tables: keep scroll inside table container

### DIFF
--- a/frontend/src/components/DetailView/common/DetailTabTable.tsx
+++ b/frontend/src/components/DetailView/common/DetailTabTable.tsx
@@ -110,6 +110,7 @@ type DetailTabTableReadSelectProps<T extends MRT_RowData> = {
   clickableRows?: boolean
   enableColumnFilterModes?: boolean
   paginationPlacement?: 'top' | 'bottom' | 'both'
+  tableContainerMaxHeight?: string | number
 }
 
 type DetailTabTableEditProps<T extends MRT_RowData> = {
@@ -126,6 +127,7 @@ type DetailTabTableEditProps<T extends MRT_RowData> = {
   renderRowActions?: MRT_TableOptions<T>['renderRowActions']
   muiTableBodyRowProps?: MRT_TableOptions<T>['muiTableBodyRowProps']
   tableName?: string
+  tableContainerMaxHeight?: string | number
 }
 
 type DetailTabTableProps<T extends MRT_RowData> = DetailTabTableReadSelectProps<T> | DetailTabTableEditProps<T>
@@ -150,6 +152,7 @@ export const DetailTabTable = <T extends MRT_RowData>(props: DetailTabTableProps
     enableColumnFilterModes,
     paginationPlacement,
     isError,
+    tableContainerMaxHeight = '60vh',
   } = props
 
   const resolvedVisibleColumns: MRT_VisibilityState = visibleColumns
@@ -177,6 +180,7 @@ export const DetailTabTable = <T extends MRT_RowData>(props: DetailTabTableProps
       enableColumnFilterModes={enableColumnFilterModes}
       paginationPlacement={paginationPlacement}
       isError={isError}
+      tableContainerMaxHeight={tableContainerMaxHeight}
     />
   )
 }
@@ -194,6 +198,7 @@ const DetailTabEditableTable = <T extends MRT_RowData>({
   renderRowActions,
   muiTableBodyRowProps,
   tableName = 'table',
+  tableContainerMaxHeight = '60vh',
 }: DetailTabTableEditProps<T>) => {
   const [pagination, setPagination] = useState<MRT_PaginationState>(paginationState ?? defaultEditPagination)
 
@@ -214,6 +219,13 @@ const DetailTabEditableTable = <T extends MRT_RowData>({
     enableRowActions,
     renderRowActions,
     muiTableBodyRowProps,
+    muiTableContainerProps: {
+      sx: {
+        maxHeight: tableContainerMaxHeight,
+        overflowY: 'auto',
+      },
+    },
+    enableStickyHeader: true,
   })
 
   return (

--- a/frontend/src/components/TableView/TableView.tsx
+++ b/frontend/src/components/TableView/TableView.tsx
@@ -73,6 +73,7 @@ export const TableView = <T extends MRT_RowData>({
   isError,
   error,
   paginationPlacement,
+  tableContainerMaxHeight,
 }: {
   data: T[] | undefined
   columns: MRT_ColumnDef<T>[]
@@ -96,6 +97,7 @@ export const TableView = <T extends MRT_RowData>({
   filterFns?: Record<string, MRT_FilterFn<T>>
   renderRowActionExtras?: ({ row }: { row: MRT_Row<T> }) => ReactNode
   paginationPlacement?: 'top' | 'bottom' | 'both'
+  tableContainerMaxHeight?: string | number
 }) => {
   const location = useLocation()
   const {
@@ -243,6 +245,15 @@ export const TableView = <T extends MRT_RowData>({
     columns: columns,
     data: data || [],
     muiTableBodyRowProps: clickableRows ? muiTableBodyRowProps : undefined,
+    muiTableContainerProps: tableContainerMaxHeight
+      ? {
+          sx: {
+            maxHeight: tableContainerMaxHeight,
+            overflowY: 'auto',
+          },
+        }
+      : undefined,
+    enableStickyHeader: Boolean(tableContainerMaxHeight),
     state: {
       columnFilters,
       showColumnFilters: true,


### PR DESCRIPTION
Refs #128

Adds a max-height + internal vertical scrolling for tables rendered via DetailTabTable (read/select/edit) so long tab tables don\x27t force the whole page to scroll on small screens. This keeps horizontal scrolling reachable without scrolling to the bottom of the browser page.