### PR TITLE
Fix invalid-field error list sync

### DIFF
--- a/frontend/src/components/DetailView/ErrorBox.test.tsx
+++ b/frontend/src/components/DetailView/ErrorBox.test.tsx
@@ -1,0 +1,71 @@
+import { describe, expect, it, jest } from '@jest/globals'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useState } from 'react'
+
+import { ErrorBox } from './components'
+import { EditableTextField } from './common/editingComponents'
+import { DetailContext, type DetailContextType, modeOptionToMode } from './Context/DetailContext'
+import { validateLocality } from '@/shared/validators/locality'
+import type { EditDataType, LocalityDetailsType } from '@/shared/types'
+import { Role } from '@/shared/types/misc'
+
+jest.mock('@/hooks/user', () => ({
+  useUser: () => ({ role: Role.Admin }),
+}))
+
+const ErrorBoxWrapper = () => {
+  const initialEditData = {
+    min_age: '',
+    max_age: 10,
+    date_meth: 'absolute',
+  } as unknown as EditDataType<LocalityDetailsType>
+  const [editData, setEditData] = useState<EditDataType<LocalityDetailsType>>(initialEditData)
+  const [fieldsWithErrors, setFieldsWithErrors] = useState({})
+
+  const contextValue: DetailContextType<LocalityDetailsType> = {
+    data: initialEditData as unknown as LocalityDetailsType,
+    mode: modeOptionToMode.new,
+    setMode: () => undefined,
+    editData,
+    setEditData,
+    isDirty: false,
+    resetEditData: () => setEditData(initialEditData),
+    textField: () => <></>,
+    bigTextField: () => <></>,
+    dropdown: () => <></>,
+    dropdownWithSearch: () => <></>,
+    radioSelection: () => <></>,
+    validator: (nextEditData, field) => {
+      if (field === 'min_age') {
+        return validateLocality(nextEditData, field)
+      }
+      return { name: String(field), error: null }
+    },
+    fieldsWithErrors,
+    setFieldsWithErrors: updaterFn => setFieldsWithErrors(updaterFn),
+  }
+
+  return (
+    <DetailContext.Provider value={contextValue as DetailContextType<unknown>}>
+      <EditableTextField<LocalityDetailsType> field="min_age" type="number" />
+      <ErrorBox<LocalityDetailsType> />
+    </DetailContext.Provider>
+  )
+}
+
+describe('ErrorBox', () => {
+  it('shows the latest validator error for a number field after typing', async () => {
+    const user = userEvent.setup()
+    render(<ErrorBoxWrapper />)
+
+    const input = screen.getByRole<HTMLInputElement>('spinbutton')
+    await user.type(input, '-1')
+
+    await waitFor(() => {
+      expect(screen.getByText('Age (min): Min value must be a positive real value')).not.toBeNull()
+    })
+
+    expect(screen.queryByText('Age (min): This field is required')).toBeNull()
+  })
+})

--- a/frontend/src/components/DetailView/common/checkFieldErrors.tsx
+++ b/frontend/src/components/DetailView/common/checkFieldErrors.tsx
@@ -1,28 +1,29 @@
 import { ValidationObject } from '@/shared/validators/validator'
-import { FieldsWithErrorsType, SetFieldsWithErrorsType } from '../DetailView'
+import type { FieldsWithErrorsType, SetFieldsWithErrorsType } from '../DetailView'
 
 export const checkFieldErrors = (
   field: string,
   errorObject: ValidationObject,
-  fieldsWithErrors: FieldsWithErrorsType,
+  _fieldsWithErrors: FieldsWithErrorsType,
   setFieldsWithErrors: SetFieldsWithErrorsType
 ) => {
   const fieldAsString = String(field)
-  if (errorObject.error) {
-    if (
-      !(fieldAsString in fieldsWithErrors) ||
-      fieldsWithErrors[fieldAsString].name !== errorObject.name ||
-      fieldsWithErrors[fieldAsString].error !== errorObject.error
-    ) {
-      setFieldsWithErrors(prevFieldsWithErrors => {
+  setFieldsWithErrors(prevFieldsWithErrors => {
+    const previousError = prevFieldsWithErrors[fieldAsString]
+
+    if (errorObject.error) {
+      if (!previousError || previousError.name !== errorObject.name || previousError.error !== errorObject.error) {
         return { ...prevFieldsWithErrors, [fieldAsString]: errorObject }
-      })
+      }
+      return prevFieldsWithErrors
     }
-  } else if (!errorObject.error && fieldAsString in fieldsWithErrors) {
-    setFieldsWithErrors(prevFieldsWithErrors => {
+
+    if (previousError) {
       const newFieldsWithErrors = { ...prevFieldsWithErrors }
       delete newFieldsWithErrors[fieldAsString]
       return newFieldsWithErrors
-    })
-  }
+    }
+
+    return prevFieldsWithErrors
+  })
 }

--- a/frontend/src/components/DetailView/common/editingComponents.tsx
+++ b/frontend/src/components/DetailView/common/editingComponents.tsx
@@ -283,6 +283,11 @@ export const EditableTextField = <T extends object>(props: EditableTextFieldProp
 
   const [numberInputValue, setNumberInputValue] = useState('')
 
+  const updateFieldErrors = (nextEditData: EditDataType<T>) => {
+    const nextErrorObject = validator(nextEditData, field)
+    checkFieldErrors(String(field), nextErrorObject, fieldsWithErrors, setFieldsWithErrors)
+  }
+
   useEffect(() => {
     if (type !== 'number') return
     const raw = editData[field]
@@ -297,7 +302,7 @@ export const EditableTextField = <T extends object>(props: EditableTextFieldProp
   useEffect(() => {
     checkFieldErrors(String(field), errorObject, fieldsWithErrors, setFieldsWithErrors)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [errorObject])
+  }, [errorObject.error, errorObject.name])
 
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     const value = event?.currentTarget?.value
@@ -305,8 +310,13 @@ export const EditableTextField = <T extends object>(props: EditableTextFieldProp
       const setNumberValue = handleSetEditData as EditableTextFieldNumberProps<T>['handleSetEditData']
       if (value === '') {
         setNumberInputValue('')
-        if (setNumberValue) setNumberValue('')
-        else setEditData({ ...editData, [field]: '' })
+        if (setNumberValue) {
+          setNumberValue('')
+        } else {
+          const nextEditData = { ...editData, [field]: '' }
+          setEditData(nextEditData)
+          updateFieldErrors(nextEditData)
+        }
         return
       }
 
@@ -316,8 +326,13 @@ export const EditableTextField = <T extends object>(props: EditableTextFieldProp
       const asNumber = Number(value)
       if (isPartialNumberInputValue(value) || Number.isNaN(asNumber)) return
 
-      if (setNumberValue) setNumberValue(asNumber)
-      else setEditData({ ...editData, [field]: asNumber })
+      if (setNumberValue) {
+        setNumberValue(asNumber)
+      } else {
+        const nextEditData = { ...editData, [field]: asNumber }
+        setEditData(nextEditData)
+        updateFieldErrors(nextEditData)
+      }
       return
     }
 
@@ -328,11 +343,17 @@ export const EditableTextField = <T extends object>(props: EditableTextFieldProp
 
     if (type === 'date') {
       // For date fields, ensure the value is stored as a string in the format 'YYYY-MM-DD'
-      setEditData({ ...editData, [field]: value })
+      const nextEditData = { ...editData, [field]: value }
+      setEditData(nextEditData)
+      updateFieldErrors(nextEditData)
     } else if (type === 'text' || value === '') {
-      setEditData({ ...editData, [field]: value })
+      const nextEditData = { ...editData, [field]: value }
+      setEditData(nextEditData)
+      updateFieldErrors(nextEditData)
     } else {
-      setEditData({ ...editData, [field]: parseFloat(value) })
+      const nextEditData = { ...editData, [field]: parseFloat(value) }
+      setEditData(nextEditData)
+      updateFieldErrors(nextEditData)
     }
   }
 

--- a/frontend/src/components/DetailView/components.tsx
+++ b/frontend/src/components/DetailView/components.tsx
@@ -14,6 +14,7 @@ import { boundingBoxSplit, isPointInBoxes } from '@/util/isPointInBox'
 import { OutOfBoundsWarningModal, OutOfBoundsWarningModalState } from './OutOfBoundsWarningModal'
 import { skipToken } from '@reduxjs/toolkit/query'
 import { finalizeEntry } from '@/services/entryApi'
+import { checkFieldErrors } from './common/checkFieldErrors'
 export { ReturnButton } from '@/components/common/ReturnButton'
 
 export const WriteButton = <T,>({
@@ -93,19 +94,7 @@ export const WriteButton = <T,>({
       for (const field in editData) {
         const fieldAsString = String(field)
         const errorObject = validator(editData, field)
-        if (errorObject.error) {
-          if (!(fieldAsString in fieldsWithErrors)) {
-            setFieldsWithErrors(prevFieldsWithErrors => {
-              return { ...prevFieldsWithErrors, [fieldAsString]: errorObject }
-            })
-          }
-        } else if (!errorObject.error && fieldAsString in fieldsWithErrors) {
-          setFieldsWithErrors(prevFieldsWithErrors => {
-            const newFieldsWithErrors = { ...prevFieldsWithErrors }
-            delete newFieldsWithErrors[fieldAsString]
-            return newFieldsWithErrors
-          })
-        }
+        checkFieldErrors(fieldAsString, errorObject, fieldsWithErrors, setFieldsWithErrors)
       }
     }
     if (mode.staging == true) {


### PR DESCRIPTION
Refs #623\n\nEnsures the invalid-fields ErrorBox always reflects the latest validator message for edited fields (notably number inputs like Locality min age).\n\n- Updates error tracking to use functional state updates (avoids stale reads)\n- Updates EditableTextField to re-validate against the next editData on change\n- Adds a focused unit test for ErrorBox