### PR TITLE
Admin emergency shutdown (maintenance mode)

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -30,9 +30,11 @@ import { errorHandler } from './middlewares/errorHandler'
 import { requireOneOf } from './middlewares/authorizer'
 import { Role } from './../../frontend/src/shared/types'
 import { blockWriteRequests } from './middlewares/misc'
+import { maintenanceGate } from './middlewares/maintenanceGate'
 import testRouter from './routes/test'
 import occurrenceRouter from './routes/occurrence'
 import speciesMergeRouter from './routes/speciesMerge'
+import adminMaintenanceRouter from './routes/adminMaintenance'
 
 const app = express()
 
@@ -51,6 +53,8 @@ app.use(refreshTokenRouter)
 app.use(tokenExtractor)
 app.use(userExtractor)
 
+app.use(maintenanceGate)
+
 app.use('/email', emailLimiter)
 
 app.use('/user', userRouter)
@@ -60,6 +64,7 @@ app.use('/locality', localityRouter)
 app.use('/locality-species', localitySpeciesRouter)
 app.use('/species', speciesRouter)
 app.use('/admin/species-merge', requireOneOf([Role.Admin]), speciesMergeRouter)
+app.use('/admin/maintenance', requireOneOf([Role.Admin]), adminMaintenanceRouter)
 app.use('/statistics', statisticsRouter)
 app.use('/reference', referenceRouter)
 app.use('/time-unit', timeUnitRouter)

--- a/backend/src/middlewares/maintenanceGate.ts
+++ b/backend/src/middlewares/maintenanceGate.ts
@@ -1,0 +1,29 @@
+import type { Middleware } from '../types'
+import { getMaintenanceState } from '../utils/maintenanceMode'
+
+const isAllowedPathDuringMaintenance = (path: string): boolean => {
+  if (path === '/version') return true
+  if (path === '/refreshToken') return true
+
+  if (path === '/user/login') return true
+  if (path === '/user/password') return true
+
+  if (path.startsWith('/admin/maintenance')) return true
+
+  return false
+}
+
+export const maintenanceGate: Middleware = (req, res, next) => {
+  if (req.method === 'OPTIONS') return next()
+
+  const maintenance = getMaintenanceState()
+  if (!maintenance.enabled) return next()
+
+  if (isAllowedPathDuringMaintenance(req.path)) return next()
+
+  return res.status(503).json({
+    maintenance: true,
+    enabledAt: maintenance.enabledAt,
+    reason: maintenance.reason,
+  })
+}

--- a/backend/src/routes/adminMaintenance.ts
+++ b/backend/src/routes/adminMaintenance.ts
@@ -1,0 +1,22 @@
+import { Router, type Request } from 'express'
+import { disableMaintenanceMode, enableMaintenanceMode, getMaintenanceState } from '../utils/maintenanceMode'
+
+const router = Router()
+
+router.get('/', (_req, res) => {
+  return res.status(200).json(getMaintenanceState())
+})
+
+router.post('/enable', (req: Request<object, object, { reason?: string }>, res) => {
+  const reason = typeof req.body.reason === 'string' ? req.body.reason : null
+  const enabledBy = req.user?.username ?? null
+  return res.status(200).json(enableMaintenanceMode(reason, enabledBy))
+})
+
+router.post('/disable', (req, res) => {
+  const previous = getMaintenanceState()
+  const next = disableMaintenanceMode()
+  res.status(200).json({ ...next, disabledBy: req.user?.username ?? null, previouslyEnabledAt: previous.enabledAt })
+})
+
+export default router

--- a/backend/src/unit-tests/middlewares/maintenanceGate.test.ts
+++ b/backend/src/unit-tests/middlewares/maintenanceGate.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, jest } from '@jest/globals'
+import type { NextFunction, Request, Response } from 'express'
+
+import { maintenanceGate } from '../../middlewares/maintenanceGate'
+import { getMaintenanceState } from '../../utils/maintenanceMode'
+
+jest.mock('../../utils/maintenanceMode', () => ({
+  getMaintenanceState: jest.fn(),
+}))
+
+const mockedGetMaintenanceState = jest.mocked(getMaintenanceState)
+
+type ResponseDouble = {
+  status: jest.MockedFunction<(code: number) => ResponseDouble>
+  json: jest.MockedFunction<(body: unknown) => ResponseDouble>
+}
+
+const createResponse = () => {
+  const res = {} as ResponseDouble
+  res.status = jest.fn((_code: number) => res) as unknown as ResponseDouble['status']
+  res.json = jest.fn((_body: unknown) => res) as unknown as ResponseDouble['json']
+
+  return res
+}
+
+describe('maintenanceGate', () => {
+  it('allows requests when maintenance is disabled', () => {
+    mockedGetMaintenanceState.mockReturnValueOnce({ enabled: false, enabledAt: null, reason: null, enabledBy: null })
+
+    const req = { method: 'GET', path: '/locality/all' } as unknown as Request
+    const res = createResponse()
+    const next = jest.fn() as unknown as NextFunction
+
+    maintenanceGate(req, res as unknown as Response, next)
+    expect(next).toHaveBeenCalledTimes(1)
+    expect(res.status).not.toHaveBeenCalled()
+    expect(res.json).not.toHaveBeenCalled()
+  })
+
+  it('blocks non-allowlisted routes with 503 when maintenance is enabled', () => {
+    mockedGetMaintenanceState.mockReturnValueOnce({
+      enabled: true,
+      enabledAt: '2026-04-17T00:00:00.000Z',
+      reason: 'db corrupted',
+      enabledBy: 'TEST',
+    })
+
+    const req = { method: 'GET', path: '/locality/all' } as unknown as Request
+    const res = createResponse()
+    const next = jest.fn() as unknown as NextFunction
+
+    maintenanceGate(req, res as unknown as Response, next)
+    expect(next).not.toHaveBeenCalled()
+    expect(res.status).toHaveBeenCalledWith(503)
+    expect(res.json).toHaveBeenCalledWith({
+      maintenance: true,
+      enabledAt: '2026-04-17T00:00:00.000Z',
+      reason: 'db corrupted',
+    })
+  })
+
+  it('allows allowlisted routes during maintenance', () => {
+    mockedGetMaintenanceState.mockReturnValueOnce({
+      enabled: true,
+      enabledAt: '2026-04-17T00:00:00.000Z',
+      reason: null,
+      enabledBy: null,
+    })
+
+    const req = { method: 'GET', path: '/version' } as unknown as Request
+    const res = createResponse()
+    const next = jest.fn() as unknown as NextFunction
+
+    maintenanceGate(req, res as unknown as Response, next)
+    expect(next).toHaveBeenCalledTimes(1)
+    expect(res.status).not.toHaveBeenCalled()
+    expect(res.json).not.toHaveBeenCalled()
+  })
+
+  it('allows OPTIONS preflight during maintenance', () => {
+    mockedGetMaintenanceState.mockReturnValueOnce({
+      enabled: true,
+      enabledAt: '2026-04-17T00:00:00.000Z',
+      reason: 'db corrupted',
+      enabledBy: 'TEST',
+    })
+
+    const req = { method: 'OPTIONS', path: '/locality/all' } as unknown as Request
+    const res = createResponse()
+    const next = jest.fn() as unknown as NextFunction
+
+    maintenanceGate(req, res as unknown as Response, next)
+    expect(next).toHaveBeenCalledTimes(1)
+  })
+})

--- a/backend/src/utils/maintenanceMode.ts
+++ b/backend/src/utils/maintenanceMode.ts
@@ -1,0 +1,81 @@
+import fs from 'fs'
+
+export type MaintenanceState = {
+  enabled: boolean
+  enabledAt: string | null
+  reason: string | null
+  enabledBy: string | null
+}
+
+const resolveStateFilePath = (): string => {
+  return process.env.NOWDB_MAINTENANCE_STATE_FILE ?? process.env.MAINTENANCE_STATE_FILE ?? '/tmp/nowdb-maintenance.json'
+}
+
+const parsePersistedState = (raw: string): MaintenanceState | null => {
+  try {
+    const parsed = JSON.parse(raw) as Partial<MaintenanceState>
+    if (typeof parsed.enabled !== 'boolean') return null
+    return {
+      enabled: parsed.enabled,
+      enabledAt: typeof parsed.enabledAt === 'string' ? parsed.enabledAt : null,
+      reason: typeof parsed.reason === 'string' ? parsed.reason : null,
+      enabledBy: typeof parsed.enabledBy === 'string' ? parsed.enabledBy : null,
+    }
+  } catch {
+    return null
+  }
+}
+
+const loadInitialState = (): MaintenanceState => {
+  const stateFilePath = resolveStateFilePath()
+  if (fs.existsSync(stateFilePath)) {
+    const persisted = parsePersistedState(fs.readFileSync(stateFilePath, 'utf8'))
+    if (persisted) return persisted
+  }
+
+  const enabledFromEnv =
+    process.env.NOWDB_MAINTENANCE_MODE === 'true' ||
+    process.env.MAINTENANCE_MODE === 'true' ||
+    process.env.VITE_MAINTENANCE_MODE === 'true'
+
+  return {
+    enabled: enabledFromEnv,
+    enabledAt: enabledFromEnv ? new Date().toISOString() : null,
+    reason:
+      process.env.NOWDB_MAINTENANCE_REASON ??
+      process.env.MAINTENANCE_REASON ??
+      process.env.VITE_MAINTENANCE_REASON ??
+      null,
+    enabledBy: null,
+  }
+}
+
+let state: MaintenanceState = loadInitialState()
+
+export const getMaintenanceState = (): MaintenanceState => ({ ...state })
+
+const persistState = (nextState: MaintenanceState) => {
+  const stateFilePath = resolveStateFilePath()
+  try {
+    fs.writeFileSync(stateFilePath, `${JSON.stringify(nextState)}\n`, { encoding: 'utf8' })
+  } catch {
+    // Best-effort: emergency mode must still work even if the filesystem is read-only.
+  }
+}
+
+export const enableMaintenanceMode = (reason: string | null, enabledBy: string | null): MaintenanceState => {
+  state = {
+    enabled: true,
+    enabledAt: new Date().toISOString(),
+    reason: reason && reason.trim() !== '' ? reason.trim() : null,
+    enabledBy: enabledBy && enabledBy.trim() !== '' ? enabledBy.trim() : null,
+  }
+  persistState(state)
+  return getMaintenanceState()
+}
+
+export const disableMaintenanceMode = (): MaintenanceState => {
+  state = { enabled: false, enabledAt: null, reason: null, enabledBy: null }
+  persistState(state)
+  return getMaintenanceState()
+}

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -36,6 +36,7 @@ export const NavBar = () => {
         { title: 'People', url: '/person' },
         { title: 'Email', url: '/email' },
         { title: 'Merge Species', url: '/admin/merge-species' },
+        { title: 'Emergency shutdown', url: '/admin/emergency-shutdown' },
       ],
     },
   ]

--- a/frontend/src/pages/MaintenancePage.tsx
+++ b/frontend/src/pages/MaintenancePage.tsx
@@ -1,0 +1,100 @@
+import { Box, Button, Divider, Stack, Typography } from '@mui/material'
+import { Link, useNavigate } from 'react-router-dom'
+import { useMemo, useState } from 'react'
+import { Role } from '@/shared/types'
+import { useUser } from '@/hooks/user'
+import { useDisableMaintenanceModeMutation } from '@/redux/maintenanceReducer'
+import { useNotify } from '@/hooks/notification'
+
+type StoredMaintenanceInfo = {
+  enabledAt: string | null
+  reason: string | null
+}
+
+const readStoredMaintenanceInfo = (): StoredMaintenanceInfo => {
+  const raw = sessionStorage.getItem('nowdb_maintenance')
+  if (!raw) return { enabledAt: null, reason: null }
+  try {
+    const parsed = JSON.parse(raw) as Partial<StoredMaintenanceInfo>
+    return {
+      enabledAt: typeof parsed.enabledAt === 'string' ? parsed.enabledAt : null,
+      reason: typeof parsed.reason === 'string' ? parsed.reason : null,
+    }
+  } catch {
+    return { enabledAt: null, reason: null }
+  }
+}
+
+export const MaintenancePage = () => {
+  const user = useUser()
+  const navigate = useNavigate()
+  const { notify } = useNotify()
+  const [disableMaintenance, { isLoading }] = useDisableMaintenanceModeMutation()
+
+  const [stored] = useState(() => readStoredMaintenanceInfo())
+  const isAdmin = user.role === Role.Admin
+
+  const header = useMemo(() => {
+    if (!stored.reason) return 'Maintenance mode'
+    return 'Maintenance mode (Emergency shutdown)'
+  }, [stored.reason])
+
+  const handleDisable = async () => {
+    try {
+      await disableMaintenance().unwrap()
+      sessionStorage.removeItem('nowdb_maintenance')
+      notify('Maintenance mode disabled', 'success')
+      navigate('/')
+    } catch {
+      notify('Failed to disable maintenance mode', 'error')
+    }
+  }
+
+  return (
+    <Box sx={{ padding: 3 }}>
+      <Stack gap={2} sx={{ maxWidth: '50em', margin: '0 auto' }}>
+        <Typography variant="h4">{header}</Typography>
+        <Divider />
+        <Typography>
+          The service is temporarily unavailable. If this is unexpected, please contact an administrator.
+        </Typography>
+
+        {stored.enabledAt && (
+          <Typography color="text.secondary">
+            Enabled at: <code>{stored.enabledAt}</code>
+          </Typography>
+        )}
+
+        {stored.reason && (
+          <Typography>
+            Reason: <strong>{stored.reason}</strong>
+          </Typography>
+        )}
+
+        <Stack direction="row" gap={1}>
+          <Button variant="outlined" component={Link} to="/login">
+            Admin login
+          </Button>
+          <Button variant="outlined" onClick={() => window.location.reload()}>
+            Retry
+          </Button>
+        </Stack>
+
+        {isAdmin && (
+          <>
+            <Divider />
+            <Typography variant="h6">Admin</Typography>
+            <Stack direction="row" gap={1}>
+              <Button variant="contained" onClick={() => void handleDisable()} disabled={isLoading}>
+                Disable maintenance mode
+              </Button>
+              <Button variant="outlined" component={Link} to="/admin/emergency-shutdown">
+                Emergency shutdown settings
+              </Button>
+            </Stack>
+          </>
+        )}
+      </Stack>
+    </Box>
+  )
+}

--- a/frontend/src/pages/admin/EmergencyShutdownPage.tsx
+++ b/frontend/src/pages/admin/EmergencyShutdownPage.tsx
@@ -1,0 +1,100 @@
+import { Box, Button, Divider, Stack, TextField, Typography } from '@mui/material'
+import { useMemo, useState } from 'react'
+import { Role } from '@/shared/types'
+import { useUser } from '@/hooks/user'
+import { useNotify } from '@/hooks/notification'
+import {
+  useDisableMaintenanceModeMutation,
+  useEnableMaintenanceModeMutation,
+  useGetMaintenanceStateQuery,
+} from '@/redux/maintenanceReducer'
+
+export const EmergencyShutdownPage = () => {
+  const user = useUser()
+  const { notify } = useNotify()
+
+  const isAdmin = user.role === Role.Admin
+  const { data, isFetching, refetch } = useGetMaintenanceStateQuery(undefined, { skip: !isAdmin })
+
+  const [reason, setReason] = useState('')
+  const [enableMaintenance, { isLoading: enabling }] = useEnableMaintenanceModeMutation()
+  const [disableMaintenance, { isLoading: disabling }] = useDisableMaintenanceModeMutation()
+
+  const currentEnabled = Boolean(data?.enabled)
+  const enabledAt = data?.enabledAt ?? null
+
+  const statusText = useMemo(() => {
+    if (!isAdmin) return 'Not authorized'
+    if (isFetching) return 'Loading...'
+    return currentEnabled ? 'ENABLED' : 'DISABLED'
+  }, [currentEnabled, isAdmin, isFetching])
+
+  if (!isAdmin) {
+    return <Box>Your user is not authorized to view this page.</Box>
+  }
+
+  document.title = 'Emergency shutdown'
+
+  const handleEnable = async () => {
+    try {
+      await enableMaintenance({ reason }).unwrap()
+      notify('Maintenance mode enabled', 'success')
+      void refetch()
+    } catch {
+      notify('Failed to enable maintenance mode', 'error')
+    }
+  }
+
+  const handleDisable = async () => {
+    try {
+      await disableMaintenance().unwrap()
+      sessionStorage.removeItem('nowdb_maintenance')
+      notify('Maintenance mode disabled', 'success')
+      void refetch()
+    } catch {
+      notify('Failed to disable maintenance mode', 'error')
+    }
+  }
+
+  return (
+    <Box sx={{ padding: 3 }}>
+      <Stack gap={2} sx={{ maxWidth: '50em', margin: '0 auto' }}>
+        <Typography variant="h4">Emergency shutdown</Typography>
+        <Typography color="text.secondary">
+          When enabled, the backend returns <code>503</code> for normal API routes. Admin maintenance endpoints remain
+          available so you can disable the mode.
+        </Typography>
+        <Divider />
+
+        <Typography>
+          Status: <strong>{statusText}</strong>
+        </Typography>
+
+        {enabledAt && (
+          <Typography color="text.secondary">
+            Enabled at: <code>{enabledAt}</code>
+          </Typography>
+        )}
+
+        <TextField
+          label="Reason (optional)"
+          value={reason}
+          onChange={event => setReason(event.currentTarget.value)}
+          disabled={currentEnabled}
+        />
+
+        <Stack direction="row" gap={1}>
+          <Button variant="contained" onClick={() => void handleEnable()} disabled={enabling || currentEnabled}>
+            Enable emergency shutdown
+          </Button>
+          <Button variant="outlined" onClick={() => void handleDisable()} disabled={disabling || !currentEnabled}>
+            Disable
+          </Button>
+          <Button variant="outlined" onClick={() => void refetch()} disabled={isFetching}>
+            Refresh status
+          </Button>
+        </Stack>
+      </Stack>
+    </Box>
+  )
+}

--- a/frontend/src/redux/api.ts
+++ b/frontend/src/redux/api.ts
@@ -33,6 +33,26 @@ const baseQueryWithReauth: BaseQueryFn<string | FetchArgs, unknown, FetchBaseQue
   extraOptions
 ) => {
   let result = await baseQuery(args, api, extraOptions)
+
+  if (result.error?.status === 503) {
+    let isMaintenance = false
+    const data = result.error.data
+    if (data && typeof data === 'object') {
+      const candidate = data as { maintenance?: unknown; enabledAt?: unknown; reason?: unknown }
+      if (candidate.maintenance === true) {
+        isMaintenance = true
+        const enabledAt = typeof candidate.enabledAt === 'string' ? candidate.enabledAt : null
+        const reason = typeof candidate.reason === 'string' ? candidate.reason : null
+        sessionStorage.setItem('nowdb_maintenance', JSON.stringify({ enabledAt, reason }))
+      }
+    }
+
+    if (isMaintenance && window.location.pathname !== '/maintenance') {
+      window.location.replace('/maintenance')
+    }
+    return result
+  }
+
   const token = (api.getState() as RootState).user.token
   if (token && result.error?.status === 401) {
     const refreshedToken = (await baseQuery(

--- a/frontend/src/redux/maintenanceReducer.ts
+++ b/frontend/src/redux/maintenanceReducer.ts
@@ -1,0 +1,37 @@
+import { api } from '@/redux/api'
+
+export type MaintenanceState = {
+  enabled: boolean
+  enabledAt: string | null
+  reason: string | null
+  enabledBy: string | null
+}
+
+export type DisableMaintenanceResponse = MaintenanceState & {
+  disabledBy: string | null
+  previouslyEnabledAt: string | null
+}
+
+const maintenanceApi = api.injectEndpoints({
+  endpoints: builder => ({
+    getMaintenanceState: builder.query<MaintenanceState, void>({
+      query: () => ({ url: '/admin/maintenance', method: 'GET' }),
+    }),
+    enableMaintenanceMode: builder.mutation<MaintenanceState, { reason?: string }>({
+      query: ({ reason }) => ({
+        url: '/admin/maintenance/enable',
+        method: 'POST',
+        body: { reason },
+      }),
+    }),
+    disableMaintenanceMode: builder.mutation<DisableMaintenanceResponse, void>({
+      query: () => ({
+        url: '/admin/maintenance/disable',
+        method: 'POST',
+      }),
+    }),
+  }),
+})
+
+export const { useGetMaintenanceStateQuery, useEnableMaintenanceModeMutation, useDisableMaintenanceModeMutation } =
+  maintenanceApi

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -75,10 +75,24 @@ const router = createBrowserRouter([
         },
       },
       {
+        path: 'admin/emergency-shutdown',
+        lazy: async () => {
+          const { EmergencyShutdownPage } = await import('../pages/admin/EmergencyShutdownPage')
+          return { Component: EmergencyShutdownPage }
+        },
+      },
+      {
         path: 'login',
         lazy: async () => {
           const { Login } = await import('../components/Login')
           return { Component: Login }
+        },
+      },
+      {
+        path: 'maintenance',
+        lazy: async () => {
+          const { MaintenancePage } = await import('../pages/MaintenancePage')
+          return { Component: MaintenancePage }
         },
       },
       { path: '*', element: <div>Page not found.</div> },


### PR DESCRIPTION
Refs #853\n\nAdds a backend maintenance gate returning 503 for normal API routes, admin-only endpoints to enable/disable it, and a frontend maintenance page + admin UI to control the mode.