### PR TITLE
Fix add-species form not resetting (#1048)

### DIFF
--- a/frontend/src/components/DetailView/common/EditingForm.tsx
+++ b/frontend/src/components/DetailView/common/EditingForm.tsx
@@ -57,7 +57,7 @@ export const EditingForm = <T extends object, ParentType extends object>({
   }
 
   const defaultValues = buildDefaultValues(existingObject)
-  const { register, trigger, formState, getValues, reset } = useForm({ defaultValues })
+  const { register, trigger, formState, getValues, reset } = useForm({ defaultValues, shouldUnregister: true })
   const { errors } = formState
   const { editData, setEditData } = useDetailContext<ParentType>()
 

--- a/frontend/src/components/DetailView/common/EditingForm.tsx
+++ b/frontend/src/components/DetailView/common/EditingForm.tsx
@@ -77,6 +77,7 @@ export const EditingForm = <T extends object, ParentType extends object>({
         [arrayFieldName]: [...(editData[arrayFieldName as keyof EditDataType<ParentType>] as Array<T>), newObject],
       })
     if (editAction) editAction(newObject)
+    reset(buildDefaultValues(existingObject))
     return true
   }
 


### PR DESCRIPTION
Refs #1048\n\nAfter saving a new entry via the shared EditingForm modal, reset the form back to its default values so repeated "Add new Species" operations start with a clean form.