### PR TITLE
Fix TimeUnit bounds validation + mesowear test

### DIFF
--- a/frontend/src/components/TimeUnit/Tabs/TimeUnitTab.tsx
+++ b/frontend/src/components/TimeUnit/Tabs/TimeUnitTab.tsx
@@ -4,6 +4,7 @@ import { TimeBoundSelection } from '@/components/DetailView/common/editingCompon
 import { emptyOption } from '@/components/DetailView/common/misc'
 import { ArrayFrame, Grouped } from '@/components/DetailView/common/tabLayoutHelpers'
 import { useDetailContext } from '@/components/DetailView/Context/DetailContext'
+import { checkFieldErrors } from '@/components/DetailView/common/checkFieldErrors'
 import { Alert, Box } from '@mui/material'
 import { EditingForm, EditingFormField } from '@/components/DetailView/common/EditingForm'
 import { SequenceSelect } from '@/components/Sequence/SequenceSelect'
@@ -15,13 +16,18 @@ const DUPLICATE_CHECK_PENDING_FIELD = 'duplicateTimeUnitNamePending'
 const DUPLICATE_CHECK_PENDING_MESSAGE = 'Checking time unit name availability...'
 
 export const TimeUnitTab = () => {
-  const { textField, dropdown, data, editData, setEditData, fieldsWithErrors, setFieldsWithErrors, mode } =
+  const { textField, dropdown, data, editData, setEditData, validator, fieldsWithErrors, setFieldsWithErrors, mode } =
     useDetailContext<TimeUnitDetailsType>()
 
   const { hasDuplicateName, isCheckingName, normalizedInputName } = useTimeUnitNameAvailability(
     editData.tu_display_name,
     data.tu_name
   )
+
+  const revalidateBounds = (nextEditData: typeof editData) => {
+    checkFieldErrors('up_bound', validator(nextEditData, 'up_bound'), fieldsWithErrors, setFieldsWithErrors)
+    checkFieldErrors('low_bound', validator(nextEditData, 'low_bound'), fieldsWithErrors, setFieldsWithErrors)
+  }
 
   useEffect(() => {
     setFieldsWithErrors(prevFieldsWithErrors => {
@@ -134,7 +140,7 @@ export const TimeUnitTab = () => {
                 buttonText="Add new time bound"
                 formFields={formFields}
                 editAction={(newUpTimeBound: TimeBound) => {
-                  setEditData({
+                  const nextEditData = {
                     ...editData,
                     up_bnd: undefined,
                     up_bound: {
@@ -142,7 +148,9 @@ export const TimeUnitTab = () => {
                       age: Number(newUpTimeBound.age),
                       b_comment: newUpTimeBound.b_comment,
                     },
-                  })
+                  }
+                  setEditData(nextEditData)
+                  revalidateBounds(nextEditData)
                 }}
               />
               <TimeBoundSelection key="up_bnd" targetField="up_bnd" />
@@ -158,7 +166,7 @@ export const TimeUnitTab = () => {
                 buttonText="Add new time bound"
                 formFields={formFields}
                 editAction={(newLowTimeBound: TimeBound) => {
-                  setEditData({
+                  const nextEditData = {
                     ...editData,
                     low_bnd: undefined,
                     low_bound: {
@@ -166,7 +174,9 @@ export const TimeUnitTab = () => {
                       age: Number(newLowTimeBound.age),
                       b_comment: newLowTimeBound.b_comment,
                     },
-                  })
+                  }
+                  setEditData(nextEditData)
+                  revalidateBounds(nextEditData)
                 }}
               />
               <TimeBoundSelection key="low_bnd" targetField="low_bnd" />

--- a/frontend/src/tests/shared/validators/speciesMesowear.test.ts
+++ b/frontend/src/tests/shared/validators/speciesMesowear.test.ts
@@ -17,7 +17,7 @@ const createSpeciesEditData = (
 describe('validateSpecies mesowear scale/value constraints', () => {
   it('rejects negative Scale Minimum', () => {
     const result = validateSpecies(createSpeciesEditData({ mw_scale_min: -1 }), 'mw_scale_min')
-    expect(result.error).toBe('Scale Minimum cannot be negative.')
+    expect(result.error).toBe('Scale Minimum must be a non-negative integer.')
   })
 
   it('rejects Scale Minimum greater than Scale Maximum', () => {
@@ -27,7 +27,7 @@ describe('validateSpecies mesowear scale/value constraints', () => {
 
   it('rejects negative Scale Maximum and values below Scale Minimum', () => {
     const negative = validateSpecies(createSpeciesEditData({ mw_scale_max: -1 }), 'mw_scale_max')
-    expect(negative.error).toBe('Scale Maximum cannot be negative.')
+    expect(negative.error).toBe('Scale Maximum must be a non-negative integer.')
 
     const lessThanMin = validateSpecies(createSpeciesEditData({ mw_scale_min: 4, mw_scale_max: 3 }), 'mw_scale_max')
     expect(lessThanMin.error).toBe('Scale Maximum cannot be less than Scale Minimum.')


### PR DESCRIPTION
- Revalidates TimeUnit upper/lower bound fields after creating/editing new bounds so stale validation errors clear and Save can re-enable (fixes Cypress write-button disabled flow).\n- Updates species mesowear validator unit tests to match current non-negative-integer messaging.