### PR TITLE
Locality Age: allow clearing basis-for-age

### DIFF
--- a/frontend/src/components/DetailView/common/editingComponents.tsx
+++ b/frontend/src/components/DetailView/common/editingComponents.tsx
@@ -5,6 +5,7 @@ import {
   SelectChangeEvent,
   MenuItem,
   TextField,
+  InputAdornment,
   RadioGroup,
   FormControlLabel,
   FormHelperText,
@@ -12,8 +13,10 @@ import {
   Box,
   Modal,
   Button,
+  IconButton,
   Autocomplete,
 } from '@mui/material'
+import CloseIcon from '@mui/icons-material/Close'
 import { cloneElement, ChangeEvent, ReactNode, useState, ReactElement, useEffect } from 'react'
 import { RegisterOptions, FieldValues, UseFormRegisterReturn, FieldErrors } from 'react-hook-form'
 import { useDetailContext } from '../Context/DetailContext'
@@ -668,6 +671,32 @@ export const BasisForAgeSelection = ({
     setOpen(false)
   }
 
+  const handleClear = () => {
+    setCurrentBasisForAge(undefined)
+
+    if (targetField === 'bfa_min') {
+      setEditData({
+        ...editData,
+        bfa_min: '',
+        min_age: undefined,
+        frac_min: '',
+      })
+      return
+    }
+
+    if (targetField === 'bfa_max') {
+      setEditData({
+        ...editData,
+        bfa_max: '',
+        max_age: undefined,
+        frac_max: '',
+      })
+      return
+    }
+
+    setEditData({ ...editData, [targetField]: '' })
+  }
+
   useEffect(() => {
     if (targetField === 'bfa_min' && currentBasisForAge) {
       setEditData({
@@ -721,7 +750,26 @@ export const BasisForAgeSelection = ({
       onClick={() => setOpen(true)}
       disabled={disabled}
       sx={{ backgroundColor: disabled ? 'grey' : '' }}
-      inputProps={{ readOnly: true }}
+      inputProps={{ 'aria-label': String(targetField) }}
+      InputProps={{
+        readOnly: true,
+        endAdornment:
+          !disabled && editData[targetField] ? (
+            <InputAdornment position="end">
+              <IconButton
+                aria-label={`Clear ${String(targetField)}`}
+                size="small"
+                onClick={event => {
+                  event.preventDefault()
+                  event.stopPropagation()
+                  handleClear()
+                }}
+              >
+                <CloseIcon fontSize="small" />
+              </IconButton>
+            </InputAdornment>
+          ) : undefined,
+      }}
     />
   )
   return (

--- a/frontend/src/components/Locality/Tabs/AgeTab.test.tsx
+++ b/frontend/src/components/Locality/Tabs/AgeTab.test.tsx
@@ -17,6 +17,10 @@ jest.mock('@/components/TimeUnit/TimeUnitTable', () => ({
   TimeUnitTable: () => <div>TimeUnitTable</div>,
 }))
 
+jest.mock('@/hooks/notification', () => ({
+  useNotify: () => ({ notify: jest.fn(), setMessage: jest.fn() }),
+}))
+
 const toDisplayValue = (option: DropdownOption | string): string => {
   if (typeof option === 'string') return option
   return option.display
@@ -50,9 +54,12 @@ const ContextWrapper = ({ children }: { children: ReactNode }) => {
   const [editData, setEditData] = useState<EditDataType<LocalityDetailsType>>(initialEditData)
 
   const setFieldValue = (field: keyof EditDataType<LocalityDetailsType>, value: string) => {
+    const trimmed = value.trim()
+    const parsedValue = trimmed === '' ? '' : /^-?\d+(\.\d+)?$/.test(trimmed) ? Number(trimmed) : (value as unknown)
+
     setEditData(prev => ({
       ...prev,
-      [field]: value === '' ? '' : Number.isNaN(Number(value)) ? value : Number(value),
+      [field]: parsedValue,
     }))
   }
 
@@ -153,8 +160,8 @@ describe('AgeTab', () => {
     expect(screen.getByLabelText<HTMLInputElement>('max_age').value).toBe('20')
     expect(screen.getByLabelText<HTMLInputElement>('bfa_min').value).toBe('tu-min-initial')
     expect(screen.getByLabelText<HTMLInputElement>('bfa_max').value).toBe('tu-max-initial')
-    expect(screen.getByLabelText<HTMLInputElement>('frac_min').value).toBe('1:2')
-    expect(screen.getByLabelText<HTMLInputElement>('frac_max').value).toBe('2:2')
+    expect(screen.getByLabelText('frac_min').textContent).toContain('Early half 1:2')
+    expect(screen.getByLabelText('frac_max').textContent).toContain('Late half 2:2')
 
     await user.click(screen.getByRole('button', { name: 'Composite' }))
 

--- a/frontend/src/components/Locality/Tabs/AgeTab.tsx
+++ b/frontend/src/components/Locality/Tabs/AgeTab.tsx
@@ -124,6 +124,7 @@ const FractionSelection = ({
         label={label}
         id={`${field}-fraction`}
         value={(editData[field] as string) || ''}
+        inputProps={{ 'aria-label': field }}
         onChange={event => {
           const nextValue = String(event.target.value)
           if (nextValue === otherFractionOptionValue) {
@@ -183,6 +184,7 @@ export const AgeTab = () => {
   if (bfaMinFetching || bfaMaxFetching) return <CircularProgress />
 
   const bfa_abs_options = [
+    emptyOption,
     'AAR',
     'Ar/Ar',
     'C14',


### PR DESCRIPTION
Refs #533\n\n- Adds an empty option for Basis for age (Absolute) min/max dropdowns\n- Adds a clear (×) control for Basis for age (Time Unit) min/max selections\n- Clears derived age/fraction when clearing the time-unit basis