### PR TITLE
Fix table column width shift on sort

### DIFF
--- a/frontend/src/components/TableView/TableView.tsx
+++ b/frontend/src/components/TableView/TableView.tsx
@@ -253,8 +253,16 @@ export const TableView = <T extends MRT_RowData>({
   const table = useMaterialReactTable({
     columns: columns,
     data: data || [],
+    muiTableProps: {
+      sx: {
+        tableLayout: 'fixed',
+      },
+    },
     muiTableHeadCellProps: {
       sx: {
+        whiteSpace: 'nowrap',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
         '& .MuiTableSortLabel-root': {
           // Reserve space for the sort icon so toggling sorting doesn't shift column widths.
           position: 'relative',
@@ -265,6 +273,17 @@ export const TableView = <T extends MRT_RowData>({
           position: 'absolute',
           right: 0,
           margin: 0,
+        },
+      },
+    },
+    muiTableBodyCellProps: {
+      sx: {
+        whiteSpace: 'nowrap',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        '&.row-actions-cell': {
+          overflow: 'visible',
+          textOverflow: 'clip',
         },
       },
     },

--- a/frontend/src/components/TableView/TableView.tsx
+++ b/frontend/src/components/TableView/TableView.tsx
@@ -253,6 +253,21 @@ export const TableView = <T extends MRT_RowData>({
   const table = useMaterialReactTable({
     columns: columns,
     data: data || [],
+    muiTableHeadCellProps: {
+      sx: {
+        '& .MuiTableSortLabel-root': {
+          // Reserve space for the sort icon so toggling sorting doesn't shift column widths.
+          position: 'relative',
+          paddingRight: '1.25em',
+        },
+        '& .MuiTableSortLabel-icon': {
+          // Keep the icon from affecting layout when it appears.
+          position: 'absolute',
+          right: 0,
+          margin: 0,
+        },
+      },
+    },
     muiTableBodyRowProps: clickableRows || selectorFn ? muiTableBodyRowProps : undefined,
     muiTableContainerProps: tableContainerMaxHeight
       ? {


### PR DESCRIPTION
Refs #940\n\nReserves header sort-icon space and positions the icon absolutely so toggling sorting does not change column widths (repro: Localities table sorting by Name).