### PR TITLE
Tables: truncate long content with hover tooltip

### DIFF
--- a/frontend/src/components/DetailView/common/tabLayoutHelpers.tsx
+++ b/frontend/src/components/DetailView/common/tabLayoutHelpers.tsx
@@ -23,13 +23,18 @@ export const ArrayToTable = ({ array, half }: { array: Array<Array<ReactNode>>; 
                 display: 'flex',
                 alignItems: 'center',
                 justifyContent: 'left',
+                minWidth: 0,
                 minHeight: '2.5em',
                 borderBottom: '1px solid rgba(224, 224, 224, 1)',
                 borderRight: '1px solid rgba(224, 224, 224, 1)',
               }}
               padding="5px"
             >
-              {typeof item === 'string' ? <b>{item}</b> : item}
+              {typeof item === 'string' ? (
+                <b style={{ overflowWrap: 'anywhere', whiteSpace: 'normal' }}>{item}</b>
+              ) : (
+                item
+              )}
             </Grid>
           ))}
         </Grid>

--- a/frontend/src/components/TableView/TableView.tsx
+++ b/frontend/src/components/TableView/TableView.tsx
@@ -39,6 +39,20 @@ const isEmptyFilterValue = (value: unknown): boolean => {
   return value === '' || value === null || value === undefined
 }
 
+const toTableCellTitle = (value: unknown): string | undefined => {
+  if (typeof value === 'string') {
+    const normalized = value.replace(/[\r\n]+/g, ' ').trim()
+    if (!normalized) return
+    return normalized.length > 500 ? `${normalized.slice(0, 500)}…` : normalized
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value)
+  }
+
+  return
+}
+
 const sanitizeColumnFilters = (filters: MRT_ColumnFiltersState): MRT_ColumnFiltersState => {
   return filters.filter(filter => !isEmptyFilterValue(filter.value))
 }
@@ -276,7 +290,8 @@ export const TableView = <T extends MRT_RowData>({
         },
       },
     },
-    muiTableBodyCellProps: {
+    muiTableBodyCellProps: ({ cell }) => ({
+      ...(cell.column.id === 'mrt-row-actions' ? {} : { title: toTableCellTitle(cell.getValue()) }),
       sx: {
         whiteSpace: 'nowrap',
         overflow: 'hidden',
@@ -286,7 +301,7 @@ export const TableView = <T extends MRT_RowData>({
           textOverflow: 'clip',
         },
       },
-    },
+    }),
     muiTableBodyRowProps: clickableRows || selectorFn ? muiTableBodyRowProps : undefined,
     muiTableContainerProps: tableContainerMaxHeight
       ? {


### PR DESCRIPTION
Refs #39\n\nDepends on #1132 (shared table layout/ellipsis styles).\n\nAdds native hover tooltips for table body cells so truncated content can be inspected without expanding column widths.