### PR TITLE
UpdateTab: format reference text for more reference types

### DIFF
--- a/frontend/src/components/DetailView/common/ReferenceList.test.tsx
+++ b/frontend/src/components/DetailView/common/ReferenceList.test.tsx
@@ -15,7 +15,7 @@ const references = [
         {
           author_surname: 'Smith',
           author_initials: 'J',
-          field_id: 1,
+          field_id: 2,
         },
       ],
       issue: null,
@@ -31,6 +31,48 @@ const references = [
       end_page: null,
       title_secondary: null,
       gen_notes: null,
+    },
+  },
+  {
+    rid: 124,
+    ref_ref: {
+      rid: 124,
+      ref_type_id: 4,
+      ref_authors: [
+        {
+          author_surname: 'Doe',
+          author_initials: 'J',
+          field_id: 2,
+        },
+      ],
+      title_primary: 'Thesis Title',
+      date_primary: 2001,
+      misc_1: 'PhD thesis',
+      publisher: 'University of Helsinki',
+      end_page: 200,
+      web_url: 'https://example.com/thesis',
+      ref_journal: null,
+    },
+  },
+  {
+    rid: 125,
+    ref_ref: {
+      rid: 125,
+      ref_type_id: 6,
+      ref_authors: [
+        {
+          author_surname: 'OrgAuthor',
+          author_initials: 'A',
+          field_id: 12,
+        },
+      ],
+      title_primary: 'Web Reference Title',
+      date_primary: 2020,
+      title_secondary: 'Some Organisation',
+      misc_1: '12 Mar',
+      web_url: 'https://example.com/page',
+      exact_date: '2026-04-21',
+      ref_journal: null,
     },
   },
 ] as unknown as AnyReference[]
@@ -54,6 +96,9 @@ describe('ReferenceList', () => {
     )
 
     expect(screen.getByText(/Smith \(1999\).*Primary Title/)).toBeTruthy()
+    expect(screen.getByText(/Doe \(2001\).*Thesis Title/)).toBeTruthy()
+    expect(screen.getByText(/Web Reference Title/)).toBeTruthy()
+    expect(screen.getByText(/Accessed 2026-04-21/)).toBeTruthy()
   })
 
   it('passes the current location as return state when navigating to reference details', async () => {
@@ -68,7 +113,8 @@ describe('ReferenceList', () => {
       </MemoryRouter>
     )
 
-    await user.click(screen.getByRole('link', { name: /view/i }))
+    const viewLinks = screen.getAllByRole('link', { name: /view/i })
+    await user.click(viewLinks[0])
 
     const path = await screen.findByTestId('reference-path')
     expect(path.textContent).toBe('/reference/123')

--- a/frontend/src/components/DetailView/common/ReferenceList.tsx
+++ b/frontend/src/components/DetailView/common/ReferenceList.tsx
@@ -1,45 +1,13 @@
 import { Card, Stack } from '@mui/material'
 import { Link, useLocation } from 'react-router-dom'
 import type { AnyReference, ReferenceOfUpdate } from '@/shared/types'
-
-const makeNameList = (names: Array<string | null>) => {
-  if (names.length === 3) {
-    return `${names[0]}, ${names[1]} & ${names[2]}`
-  } else if (names.length >= 4) {
-    return `${names[0]} et al.`
-  } else if (names.length === 2) {
-    return `${names[0]} & ${names[1]}`
-  }
-  return names[0] ?? ''
-}
+import { createReferenceSubtitle } from '@/components/Reference/referenceFormatting'
 
 const getReferenceText = (ref: ReferenceOfUpdate) => {
-  const authors = makeNameList(ref.ref_authors.map(author => author.author_surname))
-  const issue = ref.issue ? ` (${ref.issue}) ` : ''
-  if (ref.ref_type_id === 1) {
-    return `${authors} (${ref.date_primary ?? ''}). ${ref.title_primary ?? ''}. ${ref.ref_journal?.journal_title ?? ''} ${ref.volume ?? ''}${issue}${ref.start_page ?? ref.end_page ? ': ' : ''}${
-      ref.start_page ?? ''
-    }${ref.start_page && ref.end_page ? '-' : ''}${ref.end_page ?? ''}${ref.start_page || ref.end_page ? '.' : ''}${
-      ref.publisher || ref.pub_place ? `${ref.publisher || ''} ${ref.pub_place}.` : ''
-    }`
-  } else if (ref.ref_type_id === 2) {
-    return `${ref.ref_authors[0]?.field_id !== 12 ? authors : ''} (${ref.date_primary ?? ''}). ${ref.title_primary ?? ''}. ${
-      ref.publisher || ref.pub_place ? ' ' : ''
-    }${ref.publisher ?? ''}${ref.publisher && ref.pub_place ? ', ' : ''}${ref.pub_place ?? ''}${
-      ref.publisher || ref.pub_place ? '.' : ''
-    }`
-  } else if (ref.ref_type_id === 3) {
-    return `${authors} ${ref.ref_authors.length > 1 ? '(eds)' : ref.ref_authors.length === 1 ? '(ed)' : ''} ${
-      ref.title_primary ?? ''
-    }. IN: ${authors} ${ref.title_secondary ?? ''}. ${ref.start_page || ref.end_page ? 'pp.' : ''}${ref.start_page ?? ''}${
-      ref.start_page && ref.end_page ? '-' : ''
-    }${ref.end_page ?? ''}. ${ref.publisher || ref.pub_place ? ' ' : ''}${ref.publisher ?? ''}${
-      ref.publisher && ref.pub_place ? ', ' : ''
-    }${ref.publisher || ref.pub_place ? '.' : ''}`
-  }
-  return `${authors} ${ref.date_primary ? `(${ref.date_primary}). ` : ''} ${ref.title_primary?.concat('. ') ?? ''}${
-    ref.title_secondary?.concat('. ') ?? ''
-  }${ref.title_series?.concat('. ') ?? ''}${ref.gen_notes?.concat('.') ?? ''}`
+  // Centralized reference formatting (covers more ref types than 1–3).
+  // `ReferenceOfUpdate` is a narrower shape than `ReferenceDetailsType`, but `createReferenceSubtitle`
+  // intentionally supports both.
+  return createReferenceSubtitle(ref)
 }
 
 export const ReferenceList = ({ references, big }: { references: AnyReference[]; big: boolean }) => {

--- a/frontend/src/components/Reference/referenceFormatting.ts
+++ b/frontend/src/components/Reference/referenceFormatting.ts
@@ -1,4 +1,4 @@
-import type { ReferenceDetailsType } from '@/shared/types'
+import type { ReferenceDetailsType, ReferenceOfUpdate } from '@/shared/types'
 
 const makeNameList = (names: Array<string | null | undefined>) => {
   if (names.length === 3) {
@@ -11,7 +11,7 @@ const makeNameList = (names: Array<string | null | undefined>) => {
   return names[0] ?? ''
 }
 
-const getSurnamesByFieldId = (ref: ReferenceDetailsType, fieldId: number) =>
+const getSurnamesByFieldId = (ref: ReferenceDetailsType | ReferenceOfUpdate, fieldId: number) =>
   ref.ref_authors
     .filter(author => author.field_id === fieldId)
     .map(author => author.author_surname)
@@ -66,17 +66,70 @@ export const createReferenceTitle = (ref: ReferenceDetailsType): string => {
   return result.length > 0 ? result : `Reference ${ref.rid}`
 }
 
-export const createReferenceSubtitle = (ref: ReferenceDetailsType) => {
+const formatExactDate = (exactDate: unknown) => {
+  if (!exactDate) return null
+  const date = exactDate instanceof Date ? exactDate : new Date(String(exactDate))
+  if (Number.isNaN(date.getTime())) return null
+  return date.toISOString().split('T')[0]
+}
+
+const formatPages = (startPage?: number | null, endPage?: number | null) => {
+  if (!startPage && !endPage) return null
+  if (startPage && endPage && startPage !== endPage) return `${startPage}-${endPage}`
+  return `${startPage ?? endPage}`
+}
+
+const formatPublisherPlace = (publisher?: string | null, pubPlace?: string | null) => {
+  const parts = [publisher?.trim(), pubPlace?.trim()].filter(Boolean)
+  return parts.length > 0 ? parts.join(', ') : null
+}
+
+const ensurePeriod = (text: string) => (text.trim().endsWith('.') ? text.trim() : `${text.trim()}.`)
+
+const joinSegments = (segments: Array<string | null | undefined>) =>
+  segments
+    .filter((s): s is string => Boolean(s?.trim()))
+    .join(' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+const makeHeading = (ref: ReferenceDetailsType | ReferenceOfUpdate) => {
   const authorsSurnames = getSurnamesByFieldId(ref, 2)
   const editorsSurnames = getSurnamesByFieldId(ref, 12)
-  const authorsPart = `${makeNameList(authorsSurnames)}`
-  const editorsPart = `${makeNameList(editorsSurnames)} ${editorsSurnames.length > 1 ? '(eds)' : '(ed)'}`
 
-  let title = `${authorsPart} (${ref.date_primary}).`
+  const hasAuthors = authorsSurnames.length > 0
+  const hasEditors = !hasAuthors && editorsSurnames.length > 0
+
+  const authorOrEditor = hasAuthors
+    ? makeNameList(authorsSurnames)
+    : hasEditors
+      ? makeNameList(editorsSurnames)
+      : undefined
+
+  const year = ref.date_primary != null ? `${ref.date_primary}` : undefined
+
+  if (authorOrEditor && year) return `${authorOrEditor} (${year}).`
+  if (authorOrEditor) return `${authorOrEditor}.`
+  if (year) return `${year}.`
+  return undefined
+}
+
+export const createReferenceSubtitle = (ref: ReferenceDetailsType | ReferenceOfUpdate) => {
+  const heading = makeHeading(ref)
+  const exactDate = formatExactDate(ref.exact_date)
+  const pages = formatPages(ref.start_page, ref.end_page)
+  const publisherPlace = formatPublisherPlace(ref.publisher, ref.pub_place)
+
+  const authorsSurnames = getSurnamesByFieldId(ref, 2)
+  const editorsSurnames = getSurnamesByFieldId(ref, 12)
+  const editorsPart = editorsSurnames.length > 0 ? makeNameList(editorsSurnames) : undefined
+  const editorsLabel = editorsSurnames.length > 1 ? '(eds)' : '(ed)'
 
   switch (ref.ref_type_id) {
     case 1: {
-      title += ` ${ref.title_primary}. ${ref.ref_journal.journal_title}`
+      const journalTitle = ref.ref_journal?.journal_title ?? ''
+      let title = joinSegments([heading, ref.title_primary ? ensurePeriod(ref.title_primary) : null])
+      title = joinSegments([title, journalTitle ? journalTitle : null])
       if (ref.volume) {
         title += ` ${ref.volume}`
       }
@@ -95,76 +148,196 @@ export const createReferenceSubtitle = (ref: ReferenceDetailsType) => {
       if (ref.volume || ref.issue || ref.start_page || ref.end_page) {
         title += `.`
       }
-      return title
+      if (publisherPlace) title = joinSegments([title, ensurePeriod(publisherPlace)])
+      return title || `Reference ${ref.rid}`
     }
     case 2: {
-      title += ` ${ref.title_primary}.`
-      if (ref.publisher || ref.pub_place) {
-        title += ` `
-      }
-      if (ref.publisher) {
-        title += `${ref.publisher}`
-      }
-      if (ref.publisher && ref.pub_place) {
-        title += `, `
-      }
-      if (ref.pub_place) {
-        title += `${ref.pub_place}`
-      }
-      if (ref.publisher || ref.pub_place) {
-        title += `.`
-      }
-      return title
+      const pagesCount = ref.end_page ? `${ref.end_page} pp.` : null
+      return (
+        joinSegments([
+          heading,
+          ref.title_primary ? ensurePeriod(ref.title_primary) : null,
+          ref.volume ? ensurePeriod(`Ed. ${ref.volume}`) : null,
+          ref.issue ? ensurePeriod(`Vol. ${ref.issue}`) : null,
+          pagesCount ? ensurePeriod(pagesCount) : null,
+          publisherPlace ? ensurePeriod(publisherPlace) : null,
+        ]) || `Reference ${ref.rid}`
+      )
     }
     case 3: {
-      title += ` ${ref.title_primary}. IN: ${editorsPart} ${ref.title_secondary}.`
-
-      if (ref.start_page || ref.end_page) {
-        title += ` pp.`
-      }
-      if (ref.start_page) {
-        title += `${ref.start_page}`
-      }
-      if (ref.start_page && ref.end_page) {
-        title += `-`
-      }
-      if (ref.end_page) {
-        title += `${ref.end_page}`
-      }
-      if (ref.start_page || ref.end_page) {
-        title += `.`
-      }
-      if (ref.publisher || ref.pub_place) {
-        title += ` `
-      }
-      if (ref.publisher) {
-        title += `${ref.publisher}`
-      }
-      if (ref.publisher && ref.pub_place) {
-        title += `, `
-      }
-      if (ref.pub_place) {
-        title += `${ref.pub_place}`
-      }
-      if (ref.publisher || ref.pub_place) {
-        title += `.`
-      }
-      return title
+      const inSegment = joinSegments([
+        'IN:',
+        editorsPart ? `${editorsPart} ${editorsLabel}` : null,
+        ref.title_secondary ? ensurePeriod(ref.title_secondary) : null,
+      ])
+      const pagesSegment = pages ? ensurePeriod(`pp. ${pages}`) : null
+      return (
+        joinSegments([
+          heading,
+          ref.title_primary ? ensurePeriod(ref.title_primary) : null,
+          inSegment ? ensurePeriod(inSegment.replace(/\.\s*$/, '')) : null,
+          pagesSegment,
+          publisherPlace ? ensurePeriod(publisherPlace) : null,
+        ]) || `Reference ${ref.rid}`
+      )
+    }
+    case 4: {
+      // Thesis/Dissertation
+      const pagesCount = ref.end_page ? `${ref.end_page} pp.` : null
+      return (
+        joinSegments([
+          heading,
+          ref.title_primary ? ensurePeriod(ref.title_primary) : null,
+          ref.misc_1 ? ensurePeriod(ref.misc_1) : null,
+          ref.publisher ? ensurePeriod(ref.publisher) : null,
+          pagesCount ? ensurePeriod(pagesCount) : null,
+          ref.web_url ? ensurePeriod(ref.web_url) : null,
+          exactDate ? ensurePeriod(`Date: ${exactDate}`) : null,
+        ]) || `Reference ${ref.rid}`
+      )
+    }
+    case 5: {
+      // Conference Proceeding
+      const journalTitle = ref.ref_journal?.journal_title ?? ''
+      const conference = joinSegments([
+        ref.title_secondary ? `"${ref.title_secondary}"` : null,
+        ref.date_secondary != null ? `(${ref.date_secondary})` : null,
+      ])
+      const journalBits = joinSegments([
+        journalTitle || null,
+        ref.volume || null,
+        ref.issue ? `(${ref.issue})` : null,
+      ])
+      const pagesBits = pages ? `: ${pages}` : null
+      return (
+        joinSegments([
+          heading,
+          ref.title_primary ? ensurePeriod(ref.title_primary) : null,
+          conference ? ensurePeriod(`Conference: ${conference}`) : null,
+          journalBits ? ensurePeriod(joinSegments([journalBits, pagesBits])) : null,
+          publisherPlace ? ensurePeriod(publisherPlace) : null,
+        ]) || `Reference ${ref.rid}`
+      )
+    }
+    case 6: {
+      // Electronic Citation
+      return (
+        joinSegments([
+          heading,
+          ref.title_primary ? ensurePeriod(ref.title_primary) : null,
+          ref.title_secondary ? ensurePeriod(`Organisation: ${ref.title_secondary}`) : null,
+          ref.misc_1 ? ensurePeriod(`Updated ${ref.misc_1}`) : null,
+          ref.web_url ? ensurePeriod(ref.web_url) : null,
+          exactDate ? ensurePeriod(`Accessed ${exactDate}`) : null,
+        ]) || `Reference ${ref.rid}`
+      )
+    }
+    case 7: {
+      // Internet Communication
+      const toSegment = editorsPart ? ensurePeriod(`To: ${editorsPart}`) : null
+      const emails = joinSegments([
+        ref.misc_1 ? `From email: ${ref.misc_1}` : null,
+        ref.misc_2 ? `To email: ${ref.misc_2}` : null,
+      ])
+      return (
+        joinSegments([
+          heading,
+          ref.title_primary ? ensurePeriod(`Subject: ${ref.title_primary}`) : null,
+          toSegment,
+          emails ? ensurePeriod(emails) : null,
+          exactDate ? ensurePeriod(`Date: ${exactDate}`) : null,
+          ref.gen_notes ? ensurePeriod(ref.gen_notes) : null,
+        ]) || `Reference ${ref.rid}`
+      )
+    }
+    case 8: {
+      // Report
+      const reportNo = ref.volume ? ensurePeriod(`Report No. ${ref.volume}`) : null
+      const pagesSegment = pages ? ensurePeriod(`pp. ${pages}`) : null
+      return (
+        joinSegments([
+          heading,
+          ref.title_primary ? ensurePeriod(ref.title_primary) : null,
+          ref.title_secondary ? ensurePeriod(ref.title_secondary) : null,
+          reportNo,
+          pagesSegment,
+          publisherPlace ? ensurePeriod(publisherPlace) : null,
+        ]) || `Reference ${ref.rid}`
+      )
+    }
+    case 9: {
+      // Unpublished Work
+      return (
+        joinSegments([
+          heading,
+          ref.title_primary ? ensurePeriod(ref.title_primary) : null,
+          ref.title_secondary ? ensurePeriod(`Organisation: ${ref.title_secondary}`) : null,
+          ref.title_series ? ensurePeriod(ref.title_series) : null,
+          ref.gen_notes ? ensurePeriod(ref.gen_notes) : null,
+        ]) || `Reference ${ref.rid}`
+      )
+    }
+    case 10: {
+      // Personal Communication
+      const recipients = editorsPart ? ensurePeriod(`Recipients: ${editorsPart}`) : null
+      return (
+        joinSegments([
+          heading,
+          ref.misc_1 ? ensurePeriod(`Type: ${ref.misc_1}`) : null,
+          recipients,
+          exactDate ? ensurePeriod(`Date: ${exactDate}`) : null,
+          ref.gen_notes ? ensurePeriod(ref.gen_notes) : null,
+        ]) || `Reference ${ref.rid}`
+      )
+    }
+    case 11: {
+      // Manuscript
+      return (
+        joinSegments([
+          heading,
+          ref.title_primary ? ensurePeriod(ref.title_primary) : null,
+          ref.title_secondary ? ensurePeriod(`Organisation: ${ref.title_secondary}`) : null,
+          exactDate ? ensurePeriod(`Date: ${exactDate}`) : null,
+          ref.gen_notes ? ensurePeriod(ref.gen_notes) : null,
+        ]) || `Reference ${ref.rid}`
+      )
+    }
+    case 12: {
+      // Notes
+      return (
+        joinSegments([
+          heading,
+          ref.title_primary ? ensurePeriod(`Subject: ${ref.title_primary}`) : null,
+          exactDate ? ensurePeriod(`Date: ${exactDate}`) : null,
+          ref.gen_notes ? ensurePeriod(ref.gen_notes) : null,
+        ]) || `Reference ${ref.rid}`
+      )
+    }
+    case 13: {
+      // Editing
+      return (
+        joinSegments([
+          heading,
+          ref.title_primary ? ensurePeriod(ref.title_primary) : null,
+          exactDate ? ensurePeriod(`Date: ${exactDate}`) : null,
+          ref.gen_notes ? ensurePeriod(ref.gen_notes) : null,
+        ]) || `Reference ${ref.rid}`
+      )
     }
     default: {
-      if (ref.title_primary) {
-        title += ` ${ref.title_primary}.`
-      }
-      if (ref.title_secondary) {
-        title += ` ${ref.title_secondary}.`
-      }
-      if (ref.title_series) {
-        title += ` ${ref.title_series}.`
-      }
-      if (ref.gen_notes) {
-        title += ` ${ref.gen_notes}.`
-      }
-      return title
+      const fallbackAuthors = authorsSurnames.length > 0 ? makeNameList(authorsSurnames) : undefined
+      const year = ref.date_primary != null ? `${ref.date_primary}` : undefined
+      const fallbackHeading =
+        fallbackAuthors && year ? `${fallbackAuthors} (${year}).` : fallbackAuthors ? `${fallbackAuthors}.` : year ? `${year}.` : undefined
+      return (
+        joinSegments([
+          fallbackHeading,
+          ref.title_primary ? ensurePeriod(ref.title_primary) : null,
+          ref.title_secondary ? ensurePeriod(ref.title_secondary) : null,
+          ref.title_series ? ensurePeriod(ref.title_series) : null,
+          ref.gen_notes ? ensurePeriod(ref.gen_notes) : null,
+        ]) || `Reference ${ref.rid}`
+      )
     }
   }
 }

--- a/frontend/src/tests/util/createReferenceSubtitle.test.ts
+++ b/frontend/src/tests/util/createReferenceSubtitle.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from '@jest/globals'
+import { createReferenceSubtitle } from '../../components/Reference/referenceFormatting'
+
+describe('createReferenceSubtitle', () => {
+  it('formats journal references (type 1)', () => {
+    const ref = {
+      rid: 1,
+      ref_type_id: 1,
+      date_primary: 1999,
+      title_primary: 'Primary Title',
+      volume: '12',
+      issue: '3',
+      start_page: 10,
+      end_page: 20,
+      ref_authors: [{ author_surname: 'Smith', field_id: 2 }],
+      ref_journal: { journal_title: 'Journal Title' },
+    } as any
+
+    const text = createReferenceSubtitle(ref)
+    expect(text).toContain('Smith (1999)')
+    expect(text).toContain('Primary Title')
+    expect(text).toContain('Journal Title')
+    expect(text).toContain('12')
+    expect(text).toContain('(3)')
+    expect(text).toContain('10-20')
+  })
+
+  it('formats thesis references (type 4)', () => {
+    const ref = {
+      rid: 2,
+      ref_type_id: 4,
+      date_primary: 2001,
+      title_primary: 'Thesis Title',
+      misc_1: 'PhD thesis',
+      publisher: 'University of Helsinki',
+      end_page: 200,
+      web_url: 'https://example.com/thesis',
+      ref_authors: [{ author_surname: 'Doe', field_id: 2 }],
+      ref_journal: null,
+    } as any
+
+    const text = createReferenceSubtitle(ref)
+    expect(text).toContain('Doe (2001)')
+    expect(text).toContain('Thesis Title')
+    expect(text).toContain('PhD thesis')
+    expect(text).toContain('University of Helsinki')
+    expect(text).toContain('200 pp.')
+    expect(text).toContain('https://example.com/thesis')
+  })
+
+  it('formats electronic citations (type 6)', () => {
+    const ref = {
+      rid: 3,
+      ref_type_id: 6,
+      date_primary: 2020,
+      title_primary: 'Web Reference Title',
+      title_secondary: 'Some Organisation',
+      misc_1: '12 Mar',
+      web_url: 'https://example.com/page',
+      exact_date: '2026-04-21',
+      ref_authors: [{ author_surname: 'OrgAuthor', field_id: 12 }],
+      ref_journal: null,
+    } as any
+
+    const text = createReferenceSubtitle(ref)
+    expect(text).toContain('(2020)')
+    expect(text).toContain('Web Reference Title')
+    expect(text).toContain('Organisation: Some Organisation')
+    expect(text).toContain('Updated 12 Mar')
+    expect(text).toContain('https://example.com/page')
+    expect(text).toContain('Accessed 2026-04-21')
+  })
+
+  it('formats internet communication (type 7)', () => {
+    const ref = {
+      rid: 4,
+      ref_type_id: 7,
+      date_primary: 2023,
+      title_primary: 'Re: Fossils',
+      exact_date: '2026-04-21',
+      ref_authors: [{ author_surname: 'Sender', field_id: 2 }, { author_surname: 'Recipient', field_id: 12 }],
+      ref_journal: null,
+    } as any
+
+    const text = createReferenceSubtitle(ref)
+    expect(text).toContain('Sender (2023)')
+    expect(text).toContain('Subject: Re: Fossils')
+    expect(text).toContain('To: Recipient')
+    expect(text).toContain('Date: 2026-04-21')
+  })
+})
+


### PR DESCRIPTION
Refs #90\n\nUpdateTab's Reference column now uses shared reference formatting that covers many reference types (beyond 1–3), including types that depend on exact_date/web_url/misc fields. Includes targeted unit tests.