### PR TITLE
Localities table: default sort by name

### DIFF
--- a/frontend/src/components/Locality/LocalityTable.tsx
+++ b/frontend/src/components/Locality/LocalityTable.tsx
@@ -435,6 +435,7 @@ export const LocalityTable = ({ selectorFn }: { selectorFn?: (newObject: Localit
         selectorFn={selectorFn}
         checkRowRestriction={checkRowRestriction}
         idFieldName="lid"
+        defaultSorting={[{ id: 'loc_name', desc: false }]}
         columns={columns}
         isFetching={localitiesQueryIsFetching}
         isError={localitiesQueryIsError}

--- a/frontend/src/components/Reference/referenceFormatting.ts
+++ b/frontend/src/components/Reference/referenceFormatting.ts
@@ -68,7 +68,16 @@ export const createReferenceTitle = (ref: ReferenceDetailsType): string => {
 
 const formatExactDate = (exactDate: unknown) => {
   if (!exactDate) return null
-  const date = exactDate instanceof Date ? exactDate : new Date(String(exactDate))
+  if (exactDate instanceof Date) {
+    if (Number.isNaN(exactDate.getTime())) return null
+    return exactDate.toISOString().split('T')[0]
+  }
+
+  if (typeof exactDate !== 'string' && typeof exactDate !== 'number') {
+    return null
+  }
+
+  const date = new Date(exactDate)
   if (Number.isNaN(date.getTime())) return null
   return date.toISOString().split('T')[0]
 }
@@ -203,11 +212,7 @@ export const createReferenceSubtitle = (ref: ReferenceDetailsType | ReferenceOfU
         ref.title_secondary ? `"${ref.title_secondary}"` : null,
         ref.date_secondary != null ? `(${ref.date_secondary})` : null,
       ])
-      const journalBits = joinSegments([
-        journalTitle || null,
-        ref.volume || null,
-        ref.issue ? `(${ref.issue})` : null,
-      ])
+      const journalBits = joinSegments([journalTitle || null, ref.volume || null, ref.issue ? `(${ref.issue})` : null])
       const pagesBits = pages ? `: ${pages}` : null
       return (
         joinSegments([
@@ -328,7 +333,13 @@ export const createReferenceSubtitle = (ref: ReferenceDetailsType | ReferenceOfU
       const fallbackAuthors = authorsSurnames.length > 0 ? makeNameList(authorsSurnames) : undefined
       const year = ref.date_primary != null ? `${ref.date_primary}` : undefined
       const fallbackHeading =
-        fallbackAuthors && year ? `${fallbackAuthors} (${year}).` : fallbackAuthors ? `${fallbackAuthors}.` : year ? `${year}.` : undefined
+        fallbackAuthors && year
+          ? `${fallbackAuthors} (${year}).`
+          : fallbackAuthors
+            ? `${fallbackAuthors}.`
+            : year
+              ? `${year}.`
+              : undefined
       return (
         joinSegments([
           fallbackHeading,

--- a/frontend/src/components/TableView/TableView.test.tsx
+++ b/frontend/src/components/TableView/TableView.test.tsx
@@ -21,11 +21,11 @@ jest.mock('@/hooks/user', () => ({
   useUser: jest.fn(),
 }))
 
-const reactRouterDom = jest.requireActual<typeof import('react-router-dom')>('react-router-dom')
+let mockLocationSearch = ''
 
 jest.mock('react-router-dom', () => ({
-  ...reactRouterDom,
-  useLocation: () => ({ search: '', pathname: '/table' }),
+  ...jest.requireActual<typeof import('react-router-dom')>('react-router-dom'),
+  useLocation: () => ({ search: mockLocationSearch, pathname: '/table' }),
   useNavigate: () => jest.fn(),
 }))
 
@@ -44,6 +44,7 @@ const mockUseUser = useUser as jest.Mock
 
 describe('TableView table help integration', () => {
   beforeEach(() => {
+    mockLocationSearch = ''
     mockUsePageContext.mockReturnValue({
       editRights: {},
       idList: [],
@@ -72,6 +73,55 @@ describe('TableView table help integration', () => {
       localities: [],
       isFirstLogin: undefined,
     })
+  })
+
+  it('uses defaultSorting when URL sorting is explicitly empty', () => {
+    mockLocationSearch = '?&columnfilters=[]&sorting=[]&pagination={"pageIndex":0,"pageSize":25}'
+
+    const setSqlOrderBy = jest.fn()
+    mockUsePageContext.mockReturnValue({
+      editRights: {},
+      idList: [],
+      idFieldName: 'id',
+      viewName: 'test',
+      previousTableUrls: [],
+      createTitle: () => '',
+      createSubtitle: () => '',
+      sqlLimit: 25,
+      sqlOffset: 0,
+      sqlColumnFilters: [],
+      sqlOrderBy: [],
+      setIdList: jest.fn(),
+      setSqlLimit: jest.fn(),
+      setSqlOffset: jest.fn(),
+      setSqlColumnFilters: jest.fn(),
+      setSqlOrderBy,
+      setPreviousTableUrls: jest.fn(),
+    })
+
+    render(
+      <TableView<TestRow>
+        title="Test Table"
+        idFieldName="id"
+        columns={[
+          { header: 'Name', accessorKey: 'name' },
+          { header: 'Id', accessorKey: 'id' },
+        ]}
+        visibleColumns={{ name: true, id: true }}
+        data={[
+          {
+            id: '1',
+            name: 'Alpha',
+            full_count: 1,
+          },
+        ]}
+        url="test"
+        isFetching={false}
+        defaultSorting={[{ id: 'name', desc: false }]}
+      />
+    )
+
+    expect(setSqlOrderBy).toHaveBeenCalledWith([{ id: 'name', desc: false }])
   })
 
   it('shows help with multi-sort guidance for regular tables', () => {

--- a/frontend/src/components/TableView/TableView.tsx
+++ b/frontend/src/components/TableView/TableView.tsx
@@ -69,6 +69,7 @@ export const TableView = <T extends MRT_RowData>({
   columns,
   visibleColumns,
   idFieldName,
+  defaultSorting,
   checkRowRestriction,
   selectorFn,
   tableRowAction,
@@ -93,6 +94,7 @@ export const TableView = <T extends MRT_RowData>({
   columns: MRT_ColumnDef<T>[]
   visibleColumns: MRT_VisibilityState
   idFieldName: keyof T
+  defaultSorting?: MRT_SortingState
   checkRowRestriction?: (row: T) => boolean
   selectorFn?: (id: T) => void
   tableRowAction?: (row: T) => void
@@ -124,7 +126,7 @@ export const TableView = <T extends MRT_RowData>({
     setPreviousTableUrls,
   } = usePageContext()
   const [columnFilters, setColumnFilters] = useState<MRT_ColumnFiltersState>([])
-  const [sorting, setSorting] = useState<MRT_SortingState>([])
+  const [sorting, setSorting] = useState<MRT_SortingState>(defaultSorting ?? [])
   const navigate = useNavigate()
   const [pagination, setPagination] = useState<MRT_PaginationState>(
     selectorFn ? defaultPaginationSmall : defaultPagination
@@ -185,7 +187,12 @@ export const TableView = <T extends MRT_RowData>({
     return typeof candidate.pageIndex === 'number' && typeof candidate.pageSize === 'number'
   }
 
-  const loadStateFromUrl = (state: TableStateInUrl, defaultState: [] | MRT_PaginationState) => {
+  const loadStateFromUrl = <
+    TState extends MRT_ColumnFiltersState | MRT_SortingState | MRT_PaginationState,
+  >(
+    state: TableStateInUrl,
+    defaultState: TState
+  ): TState => {
     const searchParams = new URLSearchParams(location.search)
     const stateFromUrl = searchParams.get(state)
     if (!stateFromUrl) return defaultState
@@ -208,14 +215,14 @@ export const TableView = <T extends MRT_RowData>({
         }
         return columnFilter
       })
-      return normalizedFilters
+      return normalizedFilters as unknown as TState
     }
     if (state === 'sorting') {
-      return isSortingState(parsed) ? parsed : defaultState
+      return (isSortingState(parsed) ? parsed : defaultState) as TState
     }
 
     if (state === 'pagination') {
-      return isPaginationState(parsed) ? parsed : defaultState
+      return (isPaginationState(parsed) ? parsed : defaultState) as TState
     }
 
     return defaultState
@@ -441,7 +448,7 @@ export const TableView = <T extends MRT_RowData>({
   useEffect(() => {
     if (selectorFn) return
     setColumnFilters(loadStateFromUrl('columnfilters', []) as MRT_ColumnFiltersState)
-    setSorting(loadStateFromUrl('sorting', []) as MRT_SortingState)
+    setSorting(loadStateFromUrl('sorting', defaultSorting ?? []) as MRT_SortingState)
     setPagination(loadStateFromUrl('pagination', defaultPagination) as MRT_PaginationState)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])

--- a/frontend/src/components/TableView/TableView.tsx
+++ b/frontend/src/components/TableView/TableView.tsx
@@ -187,9 +187,7 @@ export const TableView = <T extends MRT_RowData>({
     return typeof candidate.pageIndex === 'number' && typeof candidate.pageSize === 'number'
   }
 
-  const loadStateFromUrl = <
-    TState extends MRT_ColumnFiltersState | MRT_SortingState | MRT_PaginationState,
-  >(
+  const loadStateFromUrl = <TState extends MRT_ColumnFiltersState | MRT_SortingState | MRT_PaginationState>(
     state: TableStateInUrl,
     defaultState: TState
   ): TState => {
@@ -447,9 +445,9 @@ export const TableView = <T extends MRT_RowData>({
   // Load state from url only on first render
   useEffect(() => {
     if (selectorFn) return
-    setColumnFilters(loadStateFromUrl('columnfilters', []) as MRT_ColumnFiltersState)
-    setSorting(loadStateFromUrl('sorting', defaultSorting ?? []) as MRT_SortingState)
-    setPagination(loadStateFromUrl('pagination', defaultPagination) as MRT_PaginationState)
+    setColumnFilters(loadStateFromUrl('columnfilters', []))
+    setSorting(loadStateFromUrl('sorting', defaultSorting ?? []))
+    setPagination(loadStateFromUrl('pagination', defaultPagination))
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 

--- a/frontend/src/components/TableView/TableView.tsx
+++ b/frontend/src/components/TableView/TableView.tsx
@@ -216,7 +216,16 @@ export const TableView = <T extends MRT_RowData>({
       return normalizedFilters as unknown as TState
     }
     if (state === 'sorting') {
-      return (isSortingState(parsed) ? parsed : defaultState) as TState
+      if (!isSortingState(parsed)) {
+        return defaultState
+      }
+
+      const fallback = defaultState as unknown as MRT_SortingState
+      if (parsed.length === 0 && fallback.length > 0) {
+        return defaultState
+      }
+
+      return parsed as unknown as TState
     }
 
     if (state === 'pagination') {

--- a/frontend/src/tests/util/createReferenceSubtitle.test.ts
+++ b/frontend/src/tests/util/createReferenceSubtitle.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from '@jest/globals'
 import { createReferenceSubtitle } from '../../components/Reference/referenceFormatting'
+import type { ReferenceDetailsType } from '@/shared/types'
 
 describe('createReferenceSubtitle', () => {
   it('formats journal references (type 1)', () => {
@@ -14,7 +15,7 @@ describe('createReferenceSubtitle', () => {
       end_page: 20,
       ref_authors: [{ author_surname: 'Smith', field_id: 2 }],
       ref_journal: { journal_title: 'Journal Title' },
-    } as any
+    } as unknown as ReferenceDetailsType
 
     const text = createReferenceSubtitle(ref)
     expect(text).toContain('Smith (1999)')
@@ -37,7 +38,7 @@ describe('createReferenceSubtitle', () => {
       web_url: 'https://example.com/thesis',
       ref_authors: [{ author_surname: 'Doe', field_id: 2 }],
       ref_journal: null,
-    } as any
+    } as unknown as ReferenceDetailsType
 
     const text = createReferenceSubtitle(ref)
     expect(text).toContain('Doe (2001)')
@@ -60,7 +61,7 @@ describe('createReferenceSubtitle', () => {
       exact_date: '2026-04-21',
       ref_authors: [{ author_surname: 'OrgAuthor', field_id: 12 }],
       ref_journal: null,
-    } as any
+    } as unknown as ReferenceDetailsType
 
     const text = createReferenceSubtitle(ref)
     expect(text).toContain('(2020)')
@@ -78,9 +79,12 @@ describe('createReferenceSubtitle', () => {
       date_primary: 2023,
       title_primary: 'Re: Fossils',
       exact_date: '2026-04-21',
-      ref_authors: [{ author_surname: 'Sender', field_id: 2 }, { author_surname: 'Recipient', field_id: 12 }],
+      ref_authors: [
+        { author_surname: 'Sender', field_id: 2 },
+        { author_surname: 'Recipient', field_id: 12 },
+      ],
       ref_journal: null,
-    } as any
+    } as unknown as ReferenceDetailsType
 
     const text = createReferenceSubtitle(ref)
     expect(text).toContain('Sender (2023)')
@@ -89,4 +93,3 @@ describe('createReferenceSubtitle', () => {
     expect(text).toContain('Date: 2026-04-21')
   })
 })
-


### PR DESCRIPTION
Fixes #1137

- Localities table now defaults to sorting by Name (A→Z) when no sorting is present in the URL.
- Implemented via an optional `defaultSorting` prop in `TableView` (used by `LocalityTable`).