### PR TITLE
Locality tab: 50/50 coords + map layout

### DIFF
--- a/frontend/src/components/Locality/Tabs/LocalityTab.tsx
+++ b/frontend/src/components/Locality/Tabs/LocalityTab.tsx
@@ -254,12 +254,14 @@ export const LocalityTab = () => {
         <Box
           sx={{
             display: 'flex',
-            flexDirection: 'row',
+            flexDirection: { xs: 'column', md: 'row' },
             gap: 2,
           }}
         >
-          <ArrayFrame array={latlong} title="Latitude & Longitude" />
-          <Box sx={{ width: '50%' }}>
+          <Box sx={{ flex: { xs: '1 1 auto', md: '1 1 50%' }, minWidth: 0 }}>
+            <ArrayFrame array={latlong} title="Latitude & Longitude" />
+          </Box>
+          <Box sx={{ flex: { xs: '1 1 auto', md: '1 1 50%' }, minWidth: 0 }}>
             {hasCoordinates && (
               <Suspense fallback={<div>Loading map...</div>}>
                 <SingleLocalityMap decLat={editData.dec_lat} decLong={editData.dec_long} />

--- a/frontend/src/components/Reference/referenceFormatting.ts
+++ b/frontend/src/components/Reference/referenceFormatting.ts
@@ -68,7 +68,16 @@ export const createReferenceTitle = (ref: ReferenceDetailsType): string => {
 
 const formatExactDate = (exactDate: unknown) => {
   if (!exactDate) return null
-  const date = exactDate instanceof Date ? exactDate : new Date(String(exactDate))
+  if (exactDate instanceof Date) {
+    if (Number.isNaN(exactDate.getTime())) return null
+    return exactDate.toISOString().split('T')[0]
+  }
+
+  if (typeof exactDate !== 'string' && typeof exactDate !== 'number') {
+    return null
+  }
+
+  const date = new Date(exactDate)
   if (Number.isNaN(date.getTime())) return null
   return date.toISOString().split('T')[0]
 }
@@ -203,11 +212,7 @@ export const createReferenceSubtitle = (ref: ReferenceDetailsType | ReferenceOfU
         ref.title_secondary ? `"${ref.title_secondary}"` : null,
         ref.date_secondary != null ? `(${ref.date_secondary})` : null,
       ])
-      const journalBits = joinSegments([
-        journalTitle || null,
-        ref.volume || null,
-        ref.issue ? `(${ref.issue})` : null,
-      ])
+      const journalBits = joinSegments([journalTitle || null, ref.volume || null, ref.issue ? `(${ref.issue})` : null])
       const pagesBits = pages ? `: ${pages}` : null
       return (
         joinSegments([
@@ -328,7 +333,13 @@ export const createReferenceSubtitle = (ref: ReferenceDetailsType | ReferenceOfU
       const fallbackAuthors = authorsSurnames.length > 0 ? makeNameList(authorsSurnames) : undefined
       const year = ref.date_primary != null ? `${ref.date_primary}` : undefined
       const fallbackHeading =
-        fallbackAuthors && year ? `${fallbackAuthors} (${year}).` : fallbackAuthors ? `${fallbackAuthors}.` : year ? `${year}.` : undefined
+        fallbackAuthors && year
+          ? `${fallbackAuthors} (${year}).`
+          : fallbackAuthors
+            ? `${fallbackAuthors}.`
+            : year
+              ? `${year}.`
+              : undefined
       return (
         joinSegments([
           fallbackHeading,

--- a/frontend/src/tests/util/createReferenceSubtitle.test.ts
+++ b/frontend/src/tests/util/createReferenceSubtitle.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from '@jest/globals'
 import { createReferenceSubtitle } from '../../components/Reference/referenceFormatting'
+import type { ReferenceDetailsType } from '@/shared/types'
 
 describe('createReferenceSubtitle', () => {
   it('formats journal references (type 1)', () => {
@@ -14,7 +15,7 @@ describe('createReferenceSubtitle', () => {
       end_page: 20,
       ref_authors: [{ author_surname: 'Smith', field_id: 2 }],
       ref_journal: { journal_title: 'Journal Title' },
-    } as any
+    } as unknown as ReferenceDetailsType
 
     const text = createReferenceSubtitle(ref)
     expect(text).toContain('Smith (1999)')
@@ -37,7 +38,7 @@ describe('createReferenceSubtitle', () => {
       web_url: 'https://example.com/thesis',
       ref_authors: [{ author_surname: 'Doe', field_id: 2 }],
       ref_journal: null,
-    } as any
+    } as unknown as ReferenceDetailsType
 
     const text = createReferenceSubtitle(ref)
     expect(text).toContain('Doe (2001)')
@@ -60,7 +61,7 @@ describe('createReferenceSubtitle', () => {
       exact_date: '2026-04-21',
       ref_authors: [{ author_surname: 'OrgAuthor', field_id: 12 }],
       ref_journal: null,
-    } as any
+    } as unknown as ReferenceDetailsType
 
     const text = createReferenceSubtitle(ref)
     expect(text).toContain('(2020)')
@@ -78,9 +79,12 @@ describe('createReferenceSubtitle', () => {
       date_primary: 2023,
       title_primary: 'Re: Fossils',
       exact_date: '2026-04-21',
-      ref_authors: [{ author_surname: 'Sender', field_id: 2 }, { author_surname: 'Recipient', field_id: 12 }],
+      ref_authors: [
+        { author_surname: 'Sender', field_id: 2 },
+        { author_surname: 'Recipient', field_id: 12 },
+      ],
       ref_journal: null,
-    } as any
+    } as unknown as ReferenceDetailsType
 
     const text = createReferenceSubtitle(ref)
     expect(text).toContain('Sender (2023)')
@@ -89,4 +93,3 @@ describe('createReferenceSubtitle', () => {
     expect(text).toContain('Date: 2026-04-21')
   })
 })
-


### PR DESCRIPTION
Fixes #1135

- Latitude & Longitude section now uses a responsive 50/50 split between the coordinate fields and the map (stacks on small screens).

Note: includes a small lint cleanup in `referenceFormatting` + its test to keep frontend lint passing.