### PR TITLE
Fix: delete species with synonyms

### DIFF
--- a/backend/src/api-tests/species/data.ts
+++ b/backend/src/api-tests/species/data.ts
@@ -142,7 +142,7 @@ export const newSpeciesBasis: EditDataType<SpeciesDetailsType & EditMetaData> = 
   references: references,
 }
 
-export const cloneSpeciesData = () => {
+export const cloneSpeciesData = (): EditDataType<SpeciesDetailsType & EditMetaData> => {
   const cloneReferences = newSpeciesBasis.references?.map(reference => ({
     ...reference,
     ref_journal: reference.ref_journal ? { ...reference.ref_journal } : undefined,

--- a/backend/src/api-tests/species/delete.test.ts
+++ b/backend/src/api-tests/species/delete.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, beforeAll, afterAll, describe, it, expect } from '@jest/globals'
 import { login, logout, resetDatabase, send, resetDatabaseTimeout } from '../utils'
 import { pool } from '../../utils/db'
+import { cloneSpeciesData } from './data'
 
 describe('Deleting a species works', () => {
   beforeAll(async () => {
@@ -25,6 +26,30 @@ describe('Deleting a species works', () => {
     expect(deleteResult.status).toEqual(200)
     const getResult = await send('species/23065', 'GET')
     expect(getResult.status).toEqual(404) // 'Species response status was not 404 after deletion'
+  })
+
+  it('Deleting succeeds for a species that has synonyms', async () => {
+    const speciesPayload = cloneSpeciesData()
+    speciesPayload.species_name = 'delete-with-synonyms-test'
+    speciesPayload.com_taxa_synonym = [
+      {
+        rowState: 'new',
+        syn_genus_name: 'Pseudodryomys',
+        syn_species_name: 'simplicidens',
+        syn_comment: 'test synonym',
+      },
+    ]
+
+    const { body: createBody, status: createStatus } = await send<{ species_id: number }>('species', 'PUT', {
+      species: { ...speciesPayload, comment: 'create species for delete synonym test' },
+    })
+    expect(createStatus).toEqual(200)
+    expect(typeof createBody.species_id).toEqual('number')
+
+    const deleteResult = await send<{ id: number }>(`species/${createBody.species_id}`, 'DELETE')
+    expect(deleteResult.status).toEqual(200)
+    const getResult = await send(`species/${createBody.species_id}`, 'GET')
+    expect(getResult.status).toEqual(404)
   })
 
   it('Deleting fails without permissions', async () => {

--- a/backend/src/services/write/species.ts
+++ b/backend/src/services/write/species.ts
@@ -7,11 +7,26 @@ import { getSpeciesDetails } from '../species'
 import { makeListRemoved } from './writeOperations/utils'
 
 const getSpeciesWriteHandler = (type: ActionType) => {
+  const baseAllowedColumns = getFieldsOfTables([
+    'com_species',
+    'now_ls',
+    'now_sau',
+    'now_sr',
+    'now_lau',
+    'com_taxa_synonym',
+  ])
+
+  // Defensive: `com_taxa_synonym.synonym_id` is required for delete/update operations when a species has synonyms.
+  // We've observed runtime failures complaining it is "Non-allowed", so ensure it is always present.
+  const allowedColumns = Array.from(
+    new Set([...baseAllowedColumns, 'synonym_id', 'species_id', 'syn_genus_name', 'syn_species_name', 'syn_comment'])
+  )
+
   return new WriteHandler({
     dbName: NOW_DB_NAME,
     table: 'com_species',
     idColumn: 'species_id',
-    allowedColumns: getFieldsOfTables(['com_species', 'now_ls', 'now_sau', 'now_sr', 'now_lau', 'com_taxa_synonym']),
+    allowedColumns,
     type,
   })
 }


### PR DESCRIPTION
Fixes #737.\n\nWhat\n- Allow synonym identifier columns in species write-handler allowedColumns.\n- Add API test coverage for deleting a species that has synonyms.\n\nVerification\n- Ran backend API test: src/api-tests/species/delete.test.ts