### PR TITLE
Add cross-search export content tests

### DIFF
--- a/backend/src/api-tests/crossSearch/export.test.ts
+++ b/backend/src/api-tests/crossSearch/export.test.ts
@@ -1,6 +1,44 @@
 import { beforeAll, afterAll, describe, it, expect } from '@jest/globals'
+import { parseString } from 'fast-csv'
+import request from 'supertest'
+import type { Response } from 'superagent'
+import app from '../../app'
 import { resetDatabase, send, resetDatabaseTimeout } from '../utils'
 import { pool } from '../../utils/db'
+
+type ResponseStream = {
+  on: (event: 'data', handler: (chunk: Buffer) => void) => void
+} & {
+  on: (event: 'end', handler: () => void) => void
+}
+
+type CsvRow = Record<string, string>
+
+const parseResponseBody = (res: Response, callback: (err: Error | null, body: Buffer) => void) => {
+  const data: Buffer[] = []
+  const stream = res as unknown as ResponseStream
+  stream.on('data', chunk => data.push(chunk))
+  stream.on('end', () => {
+    callback(null, Buffer.concat(data))
+  })
+}
+
+const parseCsvRows = async (csvContent: string) =>
+  new Promise<CsvRow[]>((resolve, reject) => {
+    const rows: CsvRow[] = []
+    parseString<CsvRow, CsvRow>(csvContent, { headers: true })
+      .on('error', reject)
+      .on('data', (row: CsvRow) => rows.push(row))
+      .on('end', () => resolve(rows))
+  })
+
+const exportCrossSearchCsv = async (body: { columnFilters: unknown[]; sorting: unknown[] }) => {
+  const response = await request(app).post('/crosssearch/export').send(body).buffer(true).parse(parseResponseBody)
+  return {
+    ...response,
+    csvContent: (response.body as Buffer).toString('utf8'),
+  }
+}
 
 describe('Getting cross-search export', () => {
   beforeAll(async () => {
@@ -49,6 +87,41 @@ describe('Getting cross-search export', () => {
     const response = await send(`crosssearch/export/[]/20`, 'GET')
     expect(response.status).toEqual(403)
     expect(response.body).toEqual({ error: 'Sorting is not an array.' })
+  })
+
+  it('exports filtered CSV content with expected headers and rows', async () => {
+    const response = await exportCrossSearchCsv({
+      columnFilters: [{ id: 'country', value: 'Spain' }],
+      sorting: [{ id: 'loc_name', desc: false }],
+    })
+
+    expect(response.status).toEqual(200)
+    expect(response.headers['content-type']).toMatch(/text\/csv/i)
+    expect(response.headers['content-disposition']).toMatch(/attachment;\s*filename="cross_search/i)
+    expect(response.csvContent).toContain('"lid_now_loc"')
+    expect(response.csvContent).toContain('"loc_name"')
+    expect(response.csvContent).toContain('"country"')
+    expect(response.csvContent).toContain('"species_name"')
+    expect(response.csvContent).not.toContain('"full_count"')
+
+    const rows = await parseCsvRows(response.csvContent)
+    expect(rows).toHaveLength(10)
+    expect(rows.every(row => row.country === 'Spain')).toBe(true)
+    expect(rows.map(row => row.loc_name)).toContain("Romanyà d'Empordà")
+    expect(rows.map(row => row.species_name)).toContain('dubia')
+  })
+
+  it('exports CSV content in the requested sorting order', async () => {
+    const response = await exportCrossSearchCsv({
+      columnFilters: [],
+      sorting: [{ id: 'lid_now_loc', desc: true }],
+    })
+
+    expect(response.status).toEqual(200)
+    const rows = await parseCsvRows(response.csvContent)
+    expect(rows).toHaveLength(20)
+    expect(rows.slice(0, 5).map(row => row.lid_now_loc)).toEqual(['28518', '28518', '28518', '28518', '28518'])
+    expect(rows.slice(5, 10).map(row => row.lid_now_loc)).toEqual(['24797', '24797', '24797', '24797', '24797'])
   })
 
   it('with invalid sorting content does not work', async () => {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2264,6 +2264,19 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
+      "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
@@ -11269,6 +11282,31 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/source-map-support/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -11630,6 +11668,36 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/terser": {
+      "version": "5.34.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.34.1.tgz",
+      "integrity": "sha512-FsJZ7iZLd/BXkz+4xrRTGJ26o/6VTjQytUk8b8OxkwcD2I+79VPJlz7qss1+zE7h8GNIScFqXcDyJ/KqBYZFVA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.8.2",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2264,19 +2264,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@jridgewell/source-map": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
-      "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.25"
-      }
-    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
@@ -11282,31 +11269,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/source-map-support/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -11668,36 +11630,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/terser": {
-      "version": "5.34.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.34.1.tgz",
-      "integrity": "sha512-FsJZ7iZLd/BXkz+4xrRTGJ26o/6VTjQytUk8b8OxkwcD2I+79VPJlz7qss1+zE7h8GNIScFqXcDyJ/KqBYZFVA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.8.2",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/terser/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",


### PR DESCRIPTION
Closes #757

## Summary
- add direct Supertest coverage for the streamed cross-search CSV export response
- parse the CSV body in the API test and assert representative headers, filtered rows, and sorted row order
- verify the export omits the internal `full_count` field from the CSV output

## Validation
- `git diff --check`
- `npm run lint:backend`
- `npm run tsc:backend`
- `cd backend && DOTENV_CONFIG_PATH=../.test.env NODE_OPTIONS='-r dotenv/config' npx jest src/api-tests/crossSearch/export.test.ts --runInBand --config jest-config.js --detectOpenHandles --forceExit`
- commit hook: `npm run lint` and `npm run tsc`