### PR TITLE
[codex] Fix toolbar column test notification context

### DIFF
--- a/frontend/src/tests/components/TableToolBarColumnButtons.test.tsx
+++ b/frontend/src/tests/components/TableToolBarColumnButtons.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it, jest } from '@jest/globals'
 import '@testing-library/jest-dom'
 import { fireEvent, render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
+import { NotificationContextProvider } from '@/components/Notification'
 import { PageContextProvider } from '@/components/Page'
 import { TableToolBar } from '@/components/TableView/TableToolBar'
 
@@ -63,15 +64,17 @@ const renderToolbar = (props?: Partial<React.ComponentProps<typeof TableToolBar>
 
   return render(
     <MemoryRouter>
-      <PageContextProvider
-        editRights={{}}
-        idFieldName="id"
-        viewName="test"
-        createTitle={() => ''}
-        createSubtitle={() => ''}
-      >
-        <TableToolBar table={table} tableName={tableName} hideLeftButtons={true} {...props} />
-      </PageContextProvider>
+      <NotificationContextProvider>
+        <PageContextProvider
+          editRights={{}}
+          idFieldName="id"
+          viewName="test"
+          createTitle={() => ''}
+          createSubtitle={() => ''}
+        >
+          <TableToolBar table={table} tableName={tableName} hideLeftButtons={true} {...props} />
+        </PageContextProvider>
+      </NotificationContextProvider>
     </MemoryRouter>
   )
 }


### PR DESCRIPTION
## Summary
- Wrap `TableToolBarColumnButtons` test renders in `NotificationContextProvider`.
- Keeps `TableToolBar` on its real `useNotify` path instead of mocking or weakening production behavior.

## Root Cause
`TableToolBar` now reads notification context through `useNotify`, but this test harness only provided router and page contexts. Rendering the component in Jest therefore hit a null notification context.

## Validation
- `npx jest src/tests/components/TableToolBarColumnButtons.test.tsx --runInBand`
- `npm run lint:frontend`
- `npm run tsc:frontend`
- commit hook: `npm run lint` and `npm run tsc`

Fixes #1164