### PR TITLE
Optimize cross-search CSV export

### DIFF
--- a/backend/src/routes/crossSearch.ts
+++ b/backend/src/routes/crossSearch.ts
@@ -15,6 +15,8 @@ import { CrossSearch } from '../../../frontend/src/shared/types'
 import { once } from 'events'
 
 const router = Router()
+const lineBreakPattern = /[\r\n]+/
+const globalLineBreakPattern = /[\r\n]+/g
 
 const parseArrayRouteParameter = (value: string, message: string) => {
   const parsedValue = JSON.parse(value) as unknown
@@ -49,17 +51,13 @@ const crossSearchLocalitiesRouteValidators: ValidationChain[] = [
   param('sorting').custom(value => parseArrayRouteParameter(value as string, 'Sorting is not an array.')),
 ]
 
-const transformFunction = (row: CrossSearch & { full_count?: number }) => {
+const transformFunction = (row: CrossSearch) => {
   const transformedRow: { [key: string]: string | number | boolean | null } = {}
-  const keys = Object.keys(row) as Array<keyof (CrossSearch & { full_count?: number })>
+  const keys = Object.keys(row) as Array<keyof CrossSearch>
   for (const key of keys) {
-    if (key === 'full_count') {
-      delete row['full_count']
-      continue
-    }
     const value = row[key]
     if (typeof value === 'string') {
-      transformedRow[key] = value.replace(/[\r\n]+/g, ' ')
+      transformedRow[key] = lineBreakPattern.test(value) ? value.replace(globalLineBreakPattern, ' ') : value
     } else {
       transformedRow[key] = row[key]
     }

--- a/backend/src/services/crossSearch.ts
+++ b/backend/src/services/crossSearch.ts
@@ -133,7 +133,8 @@ export const getCrossSearchRawSql = async (
         offset,
         convertedColumnFilters,
         convertedOrderBy,
-        descendingOrder
+        descendingOrder,
+        false
       )
       const result: Partial<CrossSearch>[] = await nowDb.$queryRaw(sql)
       if (result.length === 0) break

--- a/backend/src/services/queries/crossSearchQuery.ts
+++ b/backend/src/services/queries/crossSearchQuery.ts
@@ -102,7 +102,8 @@ export const generateCrossSearchSql = (
   offset: number | undefined,
   columnFilters: ColumnFilter[],
   orderBy: string | undefined,
-  descendingOrder: boolean
+  descendingOrder: boolean,
+  includeFullCount = true
 ) => {
   const whereClause = generateWhereClause(showAll, allowedLocalities, columnFilters)
 
@@ -310,8 +311,8 @@ export const generateCrossSearchSql = (
       now_loc.cultural_stage_3,
       now_loc.regional_culture_1,
       now_loc.regional_culture_2,
-      now_loc.regional_culture_3,
-  COUNT(*) OVER() AS full_count
+      now_loc.regional_culture_3
+  ${includeFullCount ? Prisma.sql`, COUNT(*) OVER() AS full_count` : Prisma.empty}
   FROM com_species
   INNER JOIN now_ls ON com_species.species_id = now_ls.species_id
   INNER JOIN now_loc ON now_ls.lid = now_loc.lid


### PR DESCRIPTION
Closes #908

## Summary
- skip the `full_count` window-count column when fetching cross-search export batches
- stop mutating export rows to remove `full_count`
- only normalize string line breaks when a field actually contains line breaks

## Validation
- `npm run lint:backend`
- `npm run tsc:backend`
- `cd backend && DOTENV_CONFIG_PATH=../.test.env PORT=4000 node -r dotenv/config ./node_modules/.bin/jest src/api-tests/crossSearch/export.test.ts --runInBand --config jest-config.js --detectOpenHandles --forceExit`
- pre-commit hook: `npm run lint` and `npm run tsc`