### PR TITLE
[codex] Lazy-load occurrence map code

### DIFF
--- a/frontend/src/components/CrossSearch/CrossSearchTable.tsx
+++ b/frontend/src/components/CrossSearch/CrossSearchTable.tsx
@@ -1,11 +1,10 @@
-import { useMemo } from 'react'
+import { lazy, Suspense, useMemo } from 'react'
 import { type MRT_ColumnDef, type MRT_RowData, type MRT_TableInstance } from 'material-react-table'
 import { CrossSearch, formatDevelopmentalCrownType } from '@/shared/types'
 import { TableView } from '../TableView/TableView'
 import type { ColumnVisibilityGroup } from '../TableView/TableToolBar'
 import { useGetAllCrossSearchQuery, useGetAllCrossSearchLocalitiesQuery } from '@/redux/crossSearchReducer'
 import { usePageContext } from '../Page'
-import { LocalitiesMap } from '../Map/LocalitiesMap'
 import { formatWithMaxThreeDecimals } from '@/util/numberFormatting'
 import { occurrenceLabels } from '@/constants/occurrenceLabels'
 import { OccurrenceDwcExportMenuItem } from '@/components/Occurrence/OccurrenceDwcExportMenuItem'
@@ -17,6 +16,11 @@ import {
   exportOccurrenceMapSvg,
   getUniqueCrossSearchMapExportLocalities,
 } from '@/components/Species/localitySpeciesMapExport'
+
+const LocalitiesMap = lazy(async () => {
+  const module = await import('../Map/LocalitiesMap')
+  return { default: module.LocalitiesMap }
+})
 
 export const CrossSearchTable = ({ selectorFn }: { selectorFn?: (newObject: CrossSearch) => void }) => {
   const { sqlLimit, sqlOffset, sqlColumnFilters, sqlOrderBy } = usePageContext()
@@ -1092,7 +1096,9 @@ export const CrossSearchTable = ({ selectorFn }: { selectorFn?: (newObject: Cros
 
   return (
     <>
-      <LocalitiesMap localities={localitiesData} isFetching={localitiesFetching || isFetching} />
+      <Suspense fallback={<div />}>
+        <LocalitiesMap localities={localitiesData} isFetching={localitiesFetching || isFetching} />
+      </Suspense>
       <TableView<CrossSearch>
         title={occurrenceLabels.crossSearchTitle}
         selectorFn={selectorFn}


### PR DESCRIPTION
## Summary
- Lazy-load the occurrence/cross-search `LocalitiesMap` component behind React `Suspense`.
- Keep the table render path available while the Leaflet/map chunk loads separately.

## Root cause
The occurrence table imported `LocalitiesMap` eagerly, which pulled Leaflet, marker clustering, and map CSS into the initial table module. On slower machines this can add noticeable load pressure before the user interacts with the map-heavy view.

## Validation
- `npm run lint:frontend`
- `npm run tsc:frontend`
- Commit hook also ran root lint and root TypeScript checks successfully.
- `npm run test:unit:frontend` was started but aborted because it was taking too long locally.

Refs #1056