### PR TITLE
Temporarily remove phpmyadmin service from docker compose files, since they cause…

### DIFF
--- a/docker-compose.anon.yml
+++ b/docker-compose.anon.yml
@@ -53,16 +53,5 @@ services:
       timeout: 5s
       retries: 3
 
-  phpmyadmin:
-    restart: always
-    image: phpmyadmin:5.2.1
-    environment:
-      PMA_ARBITRARY: 1
-      PMA_HOST: db-anon
-      PMA_PORT: 3306
-    ports:
-      - "8080:80"
-      - "9090:443"
-
 volumes:
   nowdb-db-anon:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -45,17 +45,6 @@ services:
     ports:
       - 127.0.0.1:3307:3306
 
-  phpmyadmin:
-    restart: always
-    image: phpmyadmin:5.2.1
-    environment:
-      PMA_ARBITRARY: 1
-      PMA_HOST: db
-      PMA_PORT: 3306
-    ports:
-      - "8080:80"
-      - "9090:443"
-
 volumes:
   nowdb-db-dev:
   nowdb-db-test:


### PR DESCRIPTION
… issues. At least on my computer, trying to run "npm run start:anon" or "npm run dev" fails, because Docker tries to attach to containers that do not exist. I don't know what causes the issue but this seems to fix it. 