### PR TITLE
[codex] Show combined time unit update history

### DIFF
--- a/backend/src/api-tests/timeUnit/create.test.ts
+++ b/backend/src/api-tests/timeUnit/create.test.ts
@@ -71,7 +71,15 @@ describe('Creating new time unit', () => {
 
     it('Update logs are correct', () => {
       const lastUpdate = createdTimeUnit!.now_tau[createdTimeUnit!.now_tau.length - 1]
+      const lastSummary = createdTimeUnit!.now_time_update[createdTimeUnit!.now_time_update.length - 1]
       expect(lastUpdate.tau_comment).toEqual(newTimeUnitBasis.comment) // 'Comment is correct'
+      expect(lastSummary).toEqual(
+        expect.objectContaining({
+          tu_name: createdTimeUnit!.tu_name,
+          tuid: lastUpdate.tuid,
+          now_tau: expect.objectContaining({ tuid: lastUpdate.tuid }),
+        })
+      )
       const logRows = lastUpdate.updates
       const expectedLogRows: Partial<LogRow>[] = [
         {

--- a/backend/src/api-tests/timeUnit/data.ts
+++ b/backend/src/api-tests/timeUnit/data.ts
@@ -43,6 +43,7 @@ export const newTimeUnitBasis: EditDataType<TimeUnitDetailsType & EditMetaData> 
   sequence: 'chlma',
   tu_comment: 'test comment',
   now_tau: [],
+  now_time_update: [],
   comment: 'test create time unit',
   references: references,
 }
@@ -56,6 +57,7 @@ export const editedTimeUnit: EditDataType<TimeUnitDetailsType & EditMetaData> = 
   sequence: 'gcss',
   tu_comment: 'test comment edited',
   now_tau: [],
+  now_time_update: [],
   comment: 'test updating time unit',
   references: references,
 }
@@ -69,6 +71,7 @@ export const conflictingTimeUnit: EditDataType<TimeUnitDetailsType & EditMetaDat
   sequence: 'magneticpolarityts',
   tu_comment: 'C2n',
   now_tau: [],
+  now_time_update: [],
   comment: 'test updating time unit',
   references: references,
 }

--- a/backend/src/api-tests/timeUnit/timeUnitsFetch.test.ts
+++ b/backend/src/api-tests/timeUnit/timeUnitsFetch.test.ts
@@ -45,7 +45,16 @@ describe('GET /time-unit endpoints', () => {
         time_update_id: number
         tuid: number | null
         lower_buid: number | null
-        lower_bound_update: { buid: number; updates: unknown[] } | null
+        lower_bound_update: {
+          buid: number
+          updates: Array<{
+            buid: number | null
+            table_name: string | null
+            column_name: string | null
+            old_data: string | null
+            new_data: string | null
+          }>
+        } | null
       }>
     }>('time-unit/langhian', 'GET')
 
@@ -58,7 +67,24 @@ describe('GET /time-unit endpoints', () => {
       lower_buid: 403,
       lower_bound_update: { buid: 403 },
     })
-    expect(lowerBoundSummary?.lower_bound_update?.updates).toEqual([])
+    expect(lowerBoundSummary?.lower_bound_update?.updates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          buid: 403,
+          table_name: 'now_tu_bound',
+          column_name: 'b_name',
+          old_data: 'Lan/Srv',
+          new_data: 'Langhian/Serravallian',
+        }),
+        expect.objectContaining({
+          buid: 403,
+          table_name: 'now_tu_bound',
+          column_name: 'age',
+          old_data: '14.8',
+          new_data: '13.82',
+        }),
+      ])
+    )
   })
 
   it('handles unexpected failures gracefully', async () => {

--- a/backend/src/api-tests/timeUnit/timeUnitsFetch.test.ts
+++ b/backend/src/api-tests/timeUnit/timeUnitsFetch.test.ts
@@ -39,6 +39,28 @@ describe('GET /time-unit endpoints', () => {
     expect(body).toEqual({ message: 'Time unit not found' })
   })
 
+  it('returns legacy time update summary rows with linked bound updates', async () => {
+    const { body, status } = await send<{
+      now_time_update: Array<{
+        time_update_id: number
+        tuid: number | null
+        lower_buid: number | null
+        lower_bound_update: { buid: number; updates: unknown[] } | null
+      }>
+    }>('time-unit/langhian', 'GET')
+
+    expect(status).toBe(200)
+
+    const lowerBoundSummary = body.now_time_update.find(update => update.time_update_id === 460)
+
+    expect(lowerBoundSummary).toMatchObject({
+      tuid: null,
+      lower_buid: 403,
+      lower_bound_update: { buid: 403 },
+    })
+    expect(lowerBoundSummary?.lower_bound_update?.updates).toEqual([])
+  })
+
   it('handles unexpected failures gracefully', async () => {
     const spy = jest.spyOn(timeUnitService, 'getAllTimeUnits').mockRejectedValueOnce(new Error('db unavailable'))
 

--- a/backend/src/api-tests/timeUnit/update.test.ts
+++ b/backend/src/api-tests/timeUnit/update.test.ts
@@ -104,7 +104,15 @@ describe('Time unit updating works', () => {
 
       const { body: createdTimeUnit } = await send<TimeUnitDetailsType>(`time-unit/${existingTimeUnit.tu_name}`, 'GET')
       const lastUpdate = createdTimeUnit.now_tau[createdTimeUnit.now_tau.length - 1]
+      const lastSummary = createdTimeUnit.now_time_update[createdTimeUnit.now_time_update.length - 1]
       expect(lastUpdate.tau_comment).toEqual(editedTimeUnit.comment) // 'Comment is correct'
+      expect(lastSummary).toEqual(
+        expect.objectContaining({
+          tu_name: existingTimeUnit.tu_name,
+          tuid: lastUpdate.tuid,
+          now_tau: expect.objectContaining({ tuid: lastUpdate.tuid }),
+        })
+      )
       const logRows = lastUpdate.updates
       const expectedLogRows: Partial<LogRow>[] = [
         {

--- a/backend/src/services/timeUnit.ts
+++ b/backend/src/services/timeUnit.ts
@@ -60,24 +60,80 @@ export const getTimeUnitDetails = async (id: string) => {
           },
         },
       },
+      now_time_update: {
+        include: {
+          now_tau: {
+            include: {
+              now_tr: {
+                include: {
+                  ref_ref: {
+                    select: referenceWithoutExactDateSelect,
+                  },
+                },
+              },
+            },
+          },
+          now_bau_now_time_update_lower_buidTonow_bau: {
+            include: {
+              now_br: {
+                include: {
+                  ref_ref: {
+                    select: referenceWithoutExactDateSelect,
+                  },
+                },
+              },
+            },
+          },
+          now_bau_now_time_update_upper_buidTonow_bau: {
+            include: {
+              now_br: {
+                include: {
+                  ref_ref: {
+                    select: referenceWithoutExactDateSelect,
+                  },
+                },
+              },
+            },
+          },
+        },
+        orderBy: [{ date: 'asc' }, { time_update_id: 'asc' }],
+      },
     },
   })
 
   if (!result) return null
 
   const tuids = result.now_tau.map(tau => tau.tuid)
-
-  const logResult = await logDb.log.findMany({ where: { tuid: { in: tuids } } })
-
-  const peopleLookup = await buildPersonLookupByInitials(
-    result.now_tau.flatMap(tau => [tau.tau_coordinator, tau.tau_authorizer])
+  const timeUpdateTuids = result.now_time_update.flatMap(update => (update.tuid ? [update.tuid] : []))
+  const timeUpdateBuids = result.now_time_update.flatMap(update =>
+    [update.lower_buid, update.upper_buid].filter((buid): buid is number => typeof buid === 'number')
   )
 
-  result.now_tau = result.now_tau.map(tau => {
+  const [timeUnitLogRows, timeBoundLogRows] = await Promise.all([
+    logDb.log.findMany({ where: { tuid: { in: Array.from(new Set([...tuids, ...timeUpdateTuids])) } } }),
+    logDb.log.findMany({ where: { buid: { in: Array.from(new Set(timeUpdateBuids)) } } }),
+  ])
+
+  const peopleLookup = await buildPersonLookupByInitials(
+    [
+      ...result.now_tau.flatMap(tau => [tau.tau_coordinator, tau.tau_authorizer]),
+      ...result.now_time_update.flatMap(update => [update.coordinator, update.authorizer]),
+      ...result.now_time_update.flatMap(update => [
+        update.now_tau?.tau_coordinator,
+        update.now_tau?.tau_authorizer,
+        update.now_bau_now_time_update_lower_buidTonow_bau?.bau_coordinator,
+        update.now_bau_now_time_update_lower_buidTonow_bau?.bau_authorizer,
+        update.now_bau_now_time_update_upper_buidTonow_bau?.bau_coordinator,
+        update.now_bau_now_time_update_upper_buidTonow_bau?.bau_authorizer,
+      ]),
+    ].filter((initials): initials is string => typeof initials === 'string')
+  )
+
+  const formatTimeUnitUpdate = (tau: (typeof result.now_tau)[number]) => {
     const coordinatorPerson = getPersonFromLookup(peopleLookup, tau.tau_coordinator)
     const authorizerPerson = getPersonFromLookup(peopleLookup, tau.tau_authorizer)
 
-    const updates = logResult.filter((logRow: (typeof logResult)[number]) => logRow.tuid === tau.tuid)
+    const updates = timeUnitLogRows.filter((logRow: (typeof timeUnitLogRows)[number]) => logRow.tuid === tau.tuid)
 
     return {
       ...tau,
@@ -86,14 +142,56 @@ export const getTimeUnitDetails = async (id: string) => {
       now_tr: addNullExactDateToReferenceJoins(tau.now_tr),
       updates,
     }
+  }
+
+  const formatTimeBoundUpdate = (
+    bau:
+      | (typeof result.now_time_update)[number]['now_bau_now_time_update_lower_buidTonow_bau']
+      | (typeof result.now_time_update)[number]['now_bau_now_time_update_upper_buidTonow_bau']
+  ) => {
+    if (!bau) return null
+
+    const coordinatorPerson = getPersonFromLookup(peopleLookup, bau.bau_coordinator)
+    const authorizerPerson = getPersonFromLookup(peopleLookup, bau.bau_authorizer)
+    const updates = timeBoundLogRows.filter((logRow: (typeof timeBoundLogRows)[number]) => logRow.buid === bau.buid)
+
+    return {
+      ...bau,
+      bau_coordinator: getPersonDisplayName(coordinatorPerson, bau.bau_coordinator),
+      bau_authorizer: getPersonDisplayName(authorizerPerson, bau.bau_authorizer),
+      now_br: addNullExactDateToReferenceJoins(bau.now_br),
+      updates,
+    }
+  }
+
+  const nowTau = result.now_tau.map(formatTimeUnitUpdate)
+  const nowTimeUpdate = result.now_time_update.map(update => {
+    const {
+      now_bau_now_time_update_lower_buidTonow_bau: lowerBoundUpdate,
+      now_bau_now_time_update_upper_buidTonow_bau: upperBoundUpdate,
+      ...timeUpdate
+    } = update
+    const coordinatorPerson = getPersonFromLookup(peopleLookup, update.coordinator)
+    const authorizerPerson = getPersonFromLookup(peopleLookup, update.authorizer)
+
+    return {
+      ...timeUpdate,
+      coordinator: getPersonDisplayName(coordinatorPerson, update.coordinator),
+      authorizer: getPersonDisplayName(authorizerPerson, update.authorizer),
+      now_tau: update.now_tau ? formatTimeUnitUpdate(update.now_tau) : null,
+      lower_bound_update: formatTimeBoundUpdate(lowerBoundUpdate),
+      upper_bound_update: formatTimeBoundUpdate(upperBoundUpdate),
+    }
   })
 
   const {
+    now_tau: _nowTau,
+    now_time_update: _nowTimeUpdate,
     now_tu_bound_now_time_unit_low_bndTonow_tu_bound: low_bound,
     now_tu_bound_now_time_unit_up_bndTonow_tu_bound: up_bound,
     ...rest
   } = result
-  return { ...rest, low_bound, up_bound }
+  return { ...rest, now_tau: nowTau, now_time_update: nowTimeUpdate, low_bound, up_bound }
 }
 
 export const getTimeUnitLocalities = async (id: string, options?: TabListQueryOptions) => {

--- a/backend/src/services/write/timeUnit.ts
+++ b/backend/src/services/write/timeUnit.ts
@@ -134,7 +134,7 @@ const getTimeUnitWriteHandler = (type: ActionType) => {
     dbName: NOW_DB_NAME,
     table: 'now_time_unit',
     idColumn: 'tu_name',
-    allowedColumns: getFieldsOfTables(['now_time_unit', 'now_tu_sequence', 'now_tau', 'now_tr']),
+    allowedColumns: getFieldsOfTables(['now_time_unit', 'now_tu_sequence', 'now_tau', 'now_tr', 'now_time_update']),
     type,
   })
 }

--- a/backend/src/services/write/timeUnit.ts
+++ b/backend/src/services/write/timeUnit.ts
@@ -160,12 +160,14 @@ export const writeTimeUnit = async (
     low_bound?: unknown
     references?: unknown
     comment?: unknown
+    now_time_update?: unknown
   }
   const {
     up_bound: _upBound,
     low_bound: _lowBound,
     references: _references,
     comment: _comment,
+    now_time_update: _nowTimeUpdate,
     ...persistableTimeUnit
   } = normalizedTimeUnit
 
@@ -177,11 +179,14 @@ export const writeTimeUnit = async (
   try {
     await writeHandler.start()
 
-    const timeUnitToPersist: EditDataType<TimeUnitDetailsType> = { ...persistableTimeUnit }
+    const timeUnitToPersist = { ...persistableTimeUnit }
 
     if (timeUnitToPersist.tu_name) {
       await writeHandler.updateObject('now_time_unit', timeUnitToPersist, ['tu_name'])
-      const { cascadeErrors, calculatorErrors, localitiesToUpdate } = await checkTimeUnitCascade(timeUnitToPersist)
+      const { cascadeErrors, calculatorErrors, localitiesToUpdate } = await checkTimeUnitCascade({
+        ...normalizedTimeUnit,
+        now_time_update: normalizedTimeUnit.now_time_update ?? [],
+      } as EditDataType<TimeUnitDetailsType>)
 
       if (calculatorErrors.length > 0 || cascadeErrors.length > 0) {
         const calculatorErrorsString =

--- a/backend/src/services/write/writeOperations/types.ts
+++ b/backend/src/services/write/writeOperations/types.ts
@@ -17,6 +17,7 @@ export type AllowedTables =
   | 'now_sau'
   | 'now_tau'
   | 'now_bau'
+  | 'now_time_update'
 
 export type PrimaryTables = 'now_loc' | 'com_species' | 'now_time_unit' | 'now_tu_bound' | 'ref_ref'
 

--- a/backend/src/services/write/writeOperations/updateLogger/prepareUpdates.ts
+++ b/backend/src/services/write/writeOperations/updateLogger/prepareUpdates.ts
@@ -3,7 +3,7 @@ import { COORDINATOR } from '../../../../utils/config'
 import { AllowedTables, ActionType, Item, LogRow, PrimaryTables, WriteItem, UpdateEntry } from '../types'
 import { WriteHandler } from '../writeHandler'
 import { filterRelevantLogRows, prefixToIdColumn, primaryTableToUpdatePrefix, tableToUpdateTargets } from './utils'
-import { createUpdateEntry, writeLogRows, writeReferences } from './writeUpdates'
+import { createTimeUpdateSummary, createUpdateEntry, writeLogRows, writeReferences } from './writeUpdates'
 
 export const logAllUpdates = async (
   writeHandler: WriteHandler,
@@ -157,6 +157,9 @@ const writeUpdateEntries = async (
     const prefix = primaryTableToUpdatePrefix[updateEntry.table]
     const createdId = await createUpdateEntry(writeHandler, prefix, COORDINATOR, authorizer, comment, updateEntry.id)
     updateEntry.entryId = createdId
+    if (updateEntry.table === 'now_time_unit') {
+      await createTimeUpdateSummary(writeHandler, updateEntry.id, createdId, COORDINATOR, authorizer, comment)
+    }
   }
   return updateEntries
 }

--- a/backend/src/services/write/writeOperations/updateLogger/writeUpdates.ts
+++ b/backend/src/services/write/writeOperations/updateLogger/writeUpdates.ts
@@ -57,6 +57,28 @@ export const createUpdateEntry = async (
   return result[idField] as number
 }
 
+export const createTimeUpdateSummary = async (
+  writeHandler: WriteHandler,
+  tuName: string | number,
+  tuid: number,
+  coordinator: string,
+  authorizer: string,
+  comment: string
+) => {
+  await writeHandler.createObject(
+    'now_time_update',
+    {
+      tu_name: String(tuName),
+      tuid,
+      coordinator,
+      authorizer,
+      date: getFormattedDate(),
+      comment,
+    },
+    ['time_update_id']
+  )
+}
+
 export const writeReferences = async (
   writeHandler: WriteHandler,
   updateEntries: UpdateEntry[],

--- a/frontend/src/components/DetailView/Context/DetailContext.tsx
+++ b/frontend/src/components/DetailView/Context/DetailContext.tsx
@@ -139,6 +139,7 @@ export type DetailContextType<T> = {
   setFieldsWithErrors: SetFieldsWithErrorsType
   isDirty: boolean
   resetEditData: () => void
+  markEditDataClean?: (editData?: unknown) => void
 }
 
 export type SetEditDataType<T> = (editData: EditDataType<T>) => void
@@ -191,6 +192,14 @@ export const DetailContextProvider = <T extends object>({
     setEditData(cloneDeep(initialEditData))
     setIsDirty(false)
   }
+
+  const markEditDataClean = (nextEditData?: unknown) => {
+    const cleanEditData = cloneDeep((nextEditData as EditDataType<T> | undefined) ?? editData)
+    setInitialEditData(cleanEditData)
+    setEditData(cloneDeep(cleanEditData))
+    setIsDirty(false)
+  }
+
   return (
     <DetailContext.Provider
       value={{
@@ -199,6 +208,7 @@ export const DetailContextProvider = <T extends object>({
         setEditData: handleSetEditData,
         isDirty,
         resetEditData,
+        markEditDataClean,
         validator: (editData: unknown, fieldName: keyof EditDataType<T>) =>
           contextState.validator(editData as EditDataType<T>, fieldName),
       }}

--- a/frontend/src/components/DetailView/DetailView.tsx
+++ b/frontend/src/components/DetailView/DetailView.tsx
@@ -118,7 +118,11 @@ export const DetailView = <T extends object>({
 }: {
   tabs: TabType[]
   data: T
-  onWrite?: (editData: EditDataType<T>, setEditData: (editData: EditDataType<T>) => void) => Promise<void>
+  onWrite?: (
+    editData: EditDataType<T>,
+    setEditData: (editData: EditDataType<T>) => void,
+    markEditDataClean?: (editData?: EditDataType<T>) => void
+  ) => Promise<void>
   validator: (editData: EditDataType<T>, field: keyof EditDataType<T>) => ValidationObject
   isNew?: boolean
   isUserPage?: boolean

--- a/frontend/src/components/DetailView/DetailView.tsx
+++ b/frontend/src/components/DetailView/DetailView.tsx
@@ -20,7 +20,7 @@ import {
 } from './common/editingComponents'
 import { DetailBrowser } from './DetailBrowser'
 import { StagingView } from './StagingView'
-import { ErrorBox, ReturnButton, WriteButton } from './components'
+import { ErrorBox, ReturnButton, WriteButton, type WriteResult } from './components'
 import { ValidationObject } from '@/shared/validators/validator'
 import { EditDataType } from '@/shared/types'
 import { usePageContext } from '../Page'
@@ -122,7 +122,7 @@ export const DetailView = <T extends object>({
     editData: EditDataType<T>,
     setEditData: (editData: EditDataType<T>) => void,
     markEditDataClean?: (editData?: EditDataType<T>) => void
-  ) => Promise<void>
+  ) => Promise<WriteResult>
   validator: (editData: EditDataType<T>, field: keyof EditDataType<T>) => ValidationObject
   isNew?: boolean
   isUserPage?: boolean

--- a/frontend/src/components/DetailView/common/defaultValues.ts
+++ b/frontend/src/components/DetailView/common/defaultValues.ts
@@ -206,6 +206,7 @@ export const emptyTimeUnit = {
     seq_name: '',
   },
   now_tau: [],
+  now_time_update: [],
 } as unknown as TimeUnitDetailsType
 
 export const emptyTimeBound = {

--- a/frontend/src/components/DetailView/components.tsx
+++ b/frontend/src/components/DetailView/components.tsx
@@ -23,13 +23,27 @@ export const WriteButton = <T,>({
   hasStagingMode = false,
   disabled = false,
 }: {
-  onWrite: (editData: EditDataType<T>, setEditData: (editData: EditDataType<T>) => void) => Promise<void>
+  onWrite: (
+    editData: EditDataType<T>,
+    setEditData: (editData: EditDataType<T>) => void,
+    markEditDataClean?: (editData?: EditDataType<T>) => void
+  ) => Promise<void>
   taxonomy?: boolean
   hasStagingMode?: boolean
   disabled?: boolean
 }) => {
-  const { data, editData, setEditData, mode, setMode, validator, fieldsWithErrors, setFieldsWithErrors, isDirty } =
-    useDetailContext<T>()
+  const {
+    data,
+    editData,
+    setEditData,
+    mode,
+    setMode,
+    validator,
+    fieldsWithErrors,
+    setFieldsWithErrors,
+    isDirty,
+    markEditDataClean,
+  } = useDetailContext<T>()
   const user = useUser()
   const [loading, setLoading] = useState(false)
   const { notify } = useNotify()
@@ -173,7 +187,7 @@ export const WriteButton = <T,>({
       }
     }
 
-    await onWrite((speciesEditData as EditDataType<T>) ?? editData, setEditData)
+    await onWrite((speciesEditData as EditDataType<T>) ?? editData, setEditData, markEditDataClean)
     setMode('read')
   }
 
@@ -193,7 +207,7 @@ export const WriteButton = <T,>({
       }
 
       setLoading(true)
-      await onWrite(editData, setEditData)
+      await onWrite(editData, setEditData, markEditDataClean)
       setLoading(false)
       setMode('read')
     }

--- a/frontend/src/components/DetailView/components.tsx
+++ b/frontend/src/components/DetailView/components.tsx
@@ -17,6 +17,9 @@ import { finalizeEntry } from '@/services/entryApi'
 import { checkFieldErrors } from './common/checkFieldErrors'
 export { ReturnButton } from '@/components/common/ReturnButton'
 
+export type AfterWriteCallback = () => void
+export type WriteResult = AfterWriteCallback | void
+
 export const WriteButton = <T,>({
   onWrite,
   taxonomy,
@@ -27,7 +30,7 @@ export const WriteButton = <T,>({
     editData: EditDataType<T>,
     setEditData: (editData: EditDataType<T>) => void,
     markEditDataClean?: (editData?: EditDataType<T>) => void
-  ) => Promise<void>
+  ) => Promise<WriteResult>
   taxonomy?: boolean
   hasStagingMode?: boolean
   disabled?: boolean
@@ -187,8 +190,9 @@ export const WriteButton = <T,>({
       }
     }
 
-    await onWrite((speciesEditData as EditDataType<T>) ?? editData, setEditData, markEditDataClean)
+    const afterWrite = await onWrite((speciesEditData as EditDataType<T>) ?? editData, setEditData, markEditDataClean)
     setMode('read')
+    setTimeout(() => afterWrite?.(), 0)
   }
 
   const handleWriteButtonClick = async () => {
@@ -207,9 +211,10 @@ export const WriteButton = <T,>({
       }
 
       setLoading(true)
-      await onWrite(editData, setEditData, markEditDataClean)
+      const afterWrite = await onWrite(editData, setEditData, markEditDataClean)
       setLoading(false)
       setMode('read')
+      setTimeout(() => afterWrite?.(), 0)
     }
 
     const result = await finalizeEntry({

--- a/frontend/src/components/DetailView/components.tsx
+++ b/frontend/src/components/DetailView/components.tsx
@@ -2,7 +2,7 @@
 import { Button, Box, Typography, CircularProgress, Divider, alpha, List, ListItemText, Tooltip } from '@mui/material'
 import { useDetailContext } from './Context/DetailContext'
 import { EditDataType, Editable, Reference, Role, Species } from '@/shared/types'
-import { useState, useEffect, Fragment } from 'react'
+import { useState, useEffect, Fragment, useContext } from 'react'
 import SaveIcon from '@mui/icons-material/Save'
 import { referenceValidator } from '@/shared/validators/validator'
 import { checkSpeciesTaxonomy, convertSpeciesTaxonomyFields, hasTaxonomyChanges } from '../../util/taxonomyUtilities'
@@ -15,6 +15,7 @@ import { OutOfBoundsWarningModal, OutOfBoundsWarningModalState } from './OutOfBo
 import { skipToken } from '@reduxjs/toolkit/query'
 import { finalizeEntry } from '@/services/entryApi'
 import { checkFieldErrors } from './common/checkFieldErrors'
+import { UnsavedChangesContext } from '../unsavedChangesContext'
 export { ReturnButton } from '@/components/common/ReturnButton'
 
 export const WriteButton = <T,>({
@@ -33,6 +34,7 @@ export const WriteButton = <T,>({
   const user = useUser()
   const [loading, setLoading] = useState(false)
   const { notify } = useNotify()
+  const unsavedChanges = useContext(UnsavedChangesContext)
   const { data: speciesData } = useGetAllSpeciesQuery(!taxonomy ? skipToken : undefined)
   const { data: synonymData } = useGetAllSynonymsQuery(!taxonomy ? skipToken : undefined)
 
@@ -174,6 +176,7 @@ export const WriteButton = <T,>({
     }
 
     await onWrite((speciesEditData as EditDataType<T>) ?? editData, setEditData)
+    unsavedChanges?.setDirty(false)
     setMode('read')
   }
 
@@ -195,6 +198,7 @@ export const WriteButton = <T,>({
       setLoading(true)
       await onWrite(editData, setEditData)
       setLoading(false)
+      unsavedChanges?.setDirty(false)
       setMode('read')
     }
 

--- a/frontend/src/components/DetailView/components.tsx
+++ b/frontend/src/components/DetailView/components.tsx
@@ -2,7 +2,7 @@
 import { Button, Box, Typography, CircularProgress, Divider, alpha, List, ListItemText, Tooltip } from '@mui/material'
 import { useDetailContext } from './Context/DetailContext'
 import { EditDataType, Editable, Reference, Role, Species } from '@/shared/types'
-import { useState, useEffect, Fragment, useContext } from 'react'
+import { useState, useEffect, Fragment } from 'react'
 import SaveIcon from '@mui/icons-material/Save'
 import { referenceValidator } from '@/shared/validators/validator'
 import { checkSpeciesTaxonomy, convertSpeciesTaxonomyFields, hasTaxonomyChanges } from '../../util/taxonomyUtilities'
@@ -15,7 +15,6 @@ import { OutOfBoundsWarningModal, OutOfBoundsWarningModalState } from './OutOfBo
 import { skipToken } from '@reduxjs/toolkit/query'
 import { finalizeEntry } from '@/services/entryApi'
 import { checkFieldErrors } from './common/checkFieldErrors'
-import { UnsavedChangesContext } from '../unsavedChangesContext'
 export { ReturnButton } from '@/components/common/ReturnButton'
 
 export const WriteButton = <T,>({
@@ -34,7 +33,6 @@ export const WriteButton = <T,>({
   const user = useUser()
   const [loading, setLoading] = useState(false)
   const { notify } = useNotify()
-  const unsavedChanges = useContext(UnsavedChangesContext)
   const { data: speciesData } = useGetAllSpeciesQuery(!taxonomy ? skipToken : undefined)
   const { data: synonymData } = useGetAllSynonymsQuery(!taxonomy ? skipToken : undefined)
 
@@ -176,7 +174,6 @@ export const WriteButton = <T,>({
     }
 
     await onWrite((speciesEditData as EditDataType<T>) ?? editData, setEditData)
-    unsavedChanges?.setDirty(false)
     setMode('read')
   }
 
@@ -198,7 +195,6 @@ export const WriteButton = <T,>({
       setLoading(true)
       await onWrite(editData, setEditData)
       setLoading(false)
-      unsavedChanges?.setDirty(false)
       setMode('read')
     }
 

--- a/frontend/src/components/Sequence/SequenceSelect.test.tsx
+++ b/frontend/src/components/Sequence/SequenceSelect.test.tsx
@@ -51,6 +51,7 @@ const renderWithContext = ({ children, data, mode = 'edit' }: ContextWrapperProp
       seq_name: 'Central Paratethys',
     },
     now_tau: [],
+    now_time_update: [],
     low_bound: {
       bid: 1,
       b_name: 'low',

--- a/frontend/src/components/TimeUnit/Tabs/TimeUnitUpdateTab.tsx
+++ b/frontend/src/components/TimeUnit/Tabs/TimeUnitUpdateTab.tsx
@@ -1,0 +1,172 @@
+import { Box, Card, Divider, Stack, Typography } from '@mui/material'
+import { MRT_ColumnDef, MRT_Row } from 'material-react-table'
+import { AnyReference, TimeBoundUpdate, TimeUnitUpdate, TimeUnitUpdateSummary, UpdateLog } from '@/shared/types'
+import { useDetailContext } from '@/components/DetailView/Context/DetailContext'
+import { EditingModal } from '@/components/DetailView/common/EditingModal'
+import { ReferenceList } from '@/components/DetailView/common/ReferenceList'
+import { SimpleTable } from '@/components/DetailView/common/SimpleTable'
+import { Grouped } from '@/components/DetailView/common/tabLayoutHelpers'
+
+const formatDate = (date: Date | string | null) => {
+  if (!date) return 'No date'
+  return new Date(date).toISOString().split('T')[0]
+}
+
+const getReferences = (update: TimeUnitUpdateSummary): AnyReference[] => [
+  ...(update.now_tau?.now_tr ?? []),
+  ...(update.lower_bound_update?.now_br ?? []),
+  ...(update.upper_bound_update?.now_br ?? []),
+]
+
+const getLinkedUpdateLabels = (update: TimeUnitUpdateSummary) => {
+  const labels: string[] = []
+  if (update.now_tau) labels.push('Time unit')
+  if (update.lower_bound_update) labels.push('Lower bound')
+  if (update.upper_bound_update) labels.push('Upper bound')
+  return labels.join(', ') || 'No linked update rows'
+}
+
+export const TimeUnitUpdateTab = () => {
+  const { data } = useDetailContext<{ now_time_update: TimeUnitUpdateSummary[] }>()
+  const updates = data.now_time_update
+
+  if (!Array.isArray(updates)) {
+    return (
+      <Grouped title="Updates">
+        <Box>No updates available.</Box>
+      </Grouped>
+    )
+  }
+
+  const columns: MRT_ColumnDef<TimeUnitUpdateSummary>[] = [
+    {
+      accessorKey: 'date',
+      header: 'Date',
+      Cell: ({ cell }) => formatDate(cell.getValue() as Date | string | null),
+    },
+    {
+      accessorKey: 'authorizer',
+      header: 'Editor',
+    },
+    {
+      accessorKey: 'coordinator',
+      header: 'Coordinator',
+    },
+    {
+      header: 'Linked updates',
+      accessorFn: getLinkedUpdateLabels,
+    },
+    {
+      header: 'References',
+      Cell: ({ row }: { row: MRT_Row<TimeUnitUpdateSummary> }) => (
+        <ReferenceList references={getReferences(row.original)} big={false} />
+      ),
+    },
+    {
+      header: 'Details',
+      Cell: ({ row }: { row: MRT_Row<TimeUnitUpdateSummary> }) => <DetailsModal update={row.original} />,
+    },
+  ]
+
+  return (
+    <Grouped title="Updates">
+      <SimpleTable columns={columns} data={updates} />
+    </Grouped>
+  )
+}
+
+const DetailsModal = ({ update }: { update: TimeUnitUpdateSummary }) => {
+  const references = getReferences(update)
+
+  return (
+    <EditingModal buttonText="Details" dataCy="update-details-button">
+      <h3>Update log</h3>
+      <Card
+        sx={{ padding: '0.4em', margin: '0.5em', paddingLeft: '1em', maxWidth: '30em', backgroundColor: 'lightblue' }}
+      >
+        <Box>
+          <p>
+            <b>Date:</b> {formatDate(update.date)}
+          </p>
+          <p>
+            <b>Editor:</b> {update.authorizer}
+          </p>
+          <p>
+            <b>Coordinator:</b> {update.coordinator}
+          </p>
+          <p>
+            <b>Comment:</b> {update.comment ?? ''}
+          </p>
+        </Box>
+      </Card>
+      <Divider />
+      <h3>References</h3>
+      {references.length === 0 ? <Box>Update has no references.</Box> : <ReferenceList references={references} big />}
+      <Divider />
+      <h3>Changed database values</h3>
+      <Stack spacing={2}>
+        <TimeUnitUpdateSection title="Time unit" update={update.now_tau} />
+        <TimeBoundUpdateSection title="Lower bound" update={update.lower_bound_update} />
+        <TimeBoundUpdateSection title="Upper bound" update={update.upper_bound_update} />
+      </Stack>
+    </EditingModal>
+  )
+}
+
+const logColumns: MRT_ColumnDef<UpdateLog>[] = [
+  {
+    header: 'Table',
+    accessorKey: 'table_name',
+  },
+  {
+    header: 'Field',
+    accessorKey: 'column_name',
+  },
+  {
+    header: 'Action',
+    accessorFn: ({ log_action }) => (log_action === 1 ? 'Delete' : log_action === 3 ? 'Update' : 'Add'),
+  },
+  {
+    header: 'Old data',
+    accessorKey: 'old_data',
+  },
+  {
+    header: 'New data',
+    accessorKey: 'new_data',
+  },
+]
+
+const ChangeLogTable = ({ updates }: { updates: UpdateLog[] }) =>
+  updates.length === 0 ? (
+    <Box>No changed database values found for this linked update.</Box>
+  ) : (
+    <SimpleTable columns={logColumns} data={updates} />
+  )
+
+const TimeUnitUpdateSection = ({ title, update }: { title: string; update: TimeUnitUpdate | null }) => {
+  if (!update) return null
+
+  return (
+    <Box>
+      <Typography variant="h6">{title}</Typography>
+      <Typography variant="body2">
+        {formatDate(update.tau_date)} / {update.tau_authorizer} / {update.tau_comment ?? ''}
+      </Typography>
+      <ChangeLogTable updates={update.updates} />
+    </Box>
+  )
+}
+
+const TimeBoundUpdateSection = ({ title, update }: { title: string; update: TimeBoundUpdate | null }) => {
+  if (!update) return null
+
+  return (
+    <Box>
+      <Typography variant="h6">{title}</Typography>
+      <Typography variant="body2">
+        {formatDate(update.bau_date)} / {update.bau_authorizer} / {update.bau_comment ?? ''}
+      </Typography>
+      <ChangeLogTable updates={update.updates} />
+    </Box>
+  )
+}

--- a/frontend/src/components/TimeUnit/TimeUnitDetails.tsx
+++ b/frontend/src/components/TimeUnit/TimeUnitDetails.tsx
@@ -53,11 +53,16 @@ export const TimeUnitDetails = ({
 
   const onWrite = async (
     editData: EditDataType<TimeUnitDetailsType>,
-    setEditData: (editData: EditDataType<TimeUnitDetailsType>) => void
+    setEditData: (editData: EditDataType<TimeUnitDetailsType>) => void,
+    markEditDataClean?: (editData?: EditDataType<TimeUnitDetailsType>) => void
   ) => {
     try {
       const normalizedEditData = normalizeRank(editData)
       const { tu_name } = await editTimeUnitRequest(normalizedEditData).unwrap()
+      markEditDataClean?.({
+        ...normalizedEditData,
+        tu_name,
+      })
       unsavedChanges?.setDirty(false)
       setTimeout(() => navigate(`/time-unit/${tu_name}`), 15)
       notify('Edited item successfully.')

--- a/frontend/src/components/TimeUnit/TimeUnitDetails.tsx
+++ b/frontend/src/components/TimeUnit/TimeUnitDetails.tsx
@@ -64,8 +64,8 @@ export const TimeUnitDetails = ({
         tu_name,
       })
       unsavedChanges?.setDirty(false)
-      setTimeout(() => navigate(`/time-unit/${tu_name}`), 15)
       notify('Edited item successfully.')
+      return () => navigate(`/time-unit/${tu_name}`)
     } catch (e) {
       if (data) {
         setEditData(makeEditData(data))

--- a/frontend/src/components/TimeUnit/TimeUnitDetails.tsx
+++ b/frontend/src/components/TimeUnit/TimeUnitDetails.tsx
@@ -65,7 +65,10 @@ export const TimeUnitDetails = ({
       })
       unsavedChanges?.setDirty(false)
       notify('Edited item successfully.')
-      return () => navigate(`/time-unit/${tu_name}`)
+      return () => {
+        unsavedChanges?.allowNextNavigation?.()
+        navigate(`/time-unit/${tu_name}`)
+      }
     } catch (e) {
       if (data) {
         setEditData(makeEditData(data))

--- a/frontend/src/components/TimeUnit/TimeUnitDetails.tsx
+++ b/frontend/src/components/TimeUnit/TimeUnitDetails.tsx
@@ -2,6 +2,7 @@ import { EditDataType, TimeUnitDetailsType } from '@/shared/types'
 import { useNotify } from '@/hooks/notification'
 import { CircularProgress } from '@mui/material'
 import { useNavigate, useParams } from 'react-router-dom'
+import { useContext } from 'react'
 import {
   formatTimeUnitWriteError,
   useEditTimeUnitMutation,
@@ -17,6 +18,7 @@ import { makeEditData } from '../DetailView/Context/DetailContext'
 import { useDeleteTimeUnit } from '@/hooks/useDeleteTimeUnit'
 import { getApiErrorMessage, isDuplicateNameError } from '@/utils/api'
 import { useTimeUnitForm } from '@/hooks/useTimeUnitForm'
+import { UnsavedChangesContext } from '../unsavedChangesContext'
 
 export const TimeUnitDetails = ({
   wrapWithUnsavedChangesProvider = true,
@@ -32,6 +34,7 @@ export const TimeUnitDetails = ({
   const [editTimeUnitRequest] = useEditTimeUnitMutation()
 
   const { notify } = useNotify()
+  const unsavedChanges = useContext(UnsavedChangesContext)
   const navigate = useNavigate()
   const { deleteTimeUnit } = useDeleteTimeUnit({
     onSuccess: () => navigate('/time-unit'),
@@ -55,6 +58,7 @@ export const TimeUnitDetails = ({
     try {
       const normalizedEditData = normalizeRank(editData)
       const { tu_name } = await editTimeUnitRequest(normalizedEditData).unwrap()
+      unsavedChanges?.setDirty(false)
       setTimeout(() => navigate(`/time-unit/${tu_name}`), 15)
       notify('Edited item successfully.')
     } catch (e) {
@@ -93,6 +97,7 @@ export const TimeUnitDetails = ({
 
   return (
     <DetailView
+      key={isNew ? 'new' : data!.tu_name}
       tabs={tabs}
       isNew={isNew}
       hasStagingMode

--- a/frontend/src/components/TimeUnit/TimeUnitDetails.tsx
+++ b/frontend/src/components/TimeUnit/TimeUnitDetails.tsx
@@ -8,10 +8,10 @@ import {
   useGetTimeUnitDetailsQuery,
 } from '../../redux/timeUnitReducer'
 import { emptyTimeUnit } from '../DetailView/common/defaultValues'
-import { UpdateTab } from '../DetailView/common/UpdateTab'
 import { DetailView, TabType } from '../DetailView/DetailView'
 import { LocalityTab } from './Tabs/LocalityTab'
 import { TimeUnitTab } from './Tabs/TimeUnitTab'
+import { TimeUnitUpdateTab } from './Tabs/TimeUnitUpdateTab'
 import { validateTimeUnit } from '@/shared/validators/timeUnit'
 import { makeEditData } from '../DetailView/Context/DetailContext'
 import { useDeleteTimeUnit } from '@/hooks/useDeleteTimeUnit'
@@ -87,7 +87,7 @@ export const TimeUnitDetails = ({
     },
     {
       title: 'Updates',
-      content: <UpdateTab refFieldName="now_tr" updatesFieldName="now_tau" prefix="tau" />,
+      content: <TimeUnitUpdateTab />,
     },
   ]
 

--- a/frontend/src/components/UnsavedChangesProvider.tsx
+++ b/frontend/src/components/UnsavedChangesProvider.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from 'react'
+import { useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { UNSAFE_DataRouterContext, useBlocker } from 'react-router-dom'
 
 import { UnsavedChangesDialog } from './UnsavedChangesDialog'
@@ -20,12 +20,13 @@ const unblockedState = {
 }
 
 type BlockerState = typeof unblockedState | ReturnType<typeof useBlocker>
+type BlockerPredicate = Parameters<typeof useBlocker>[0]
 
 const BlockerBridge = ({
   shouldBlock,
   onChange,
 }: {
-  shouldBlock: boolean
+  shouldBlock: BlockerPredicate
   onChange: (blocker: ReturnType<typeof useBlocker>) => void
 }) => {
   const blocker = useBlocker(shouldBlock)
@@ -45,6 +46,7 @@ export const UnsavedChangesProvider = ({
   const [isDirty, setDirty] = useState(false)
   const [message, setMessage] = useState(defaultMessage)
   const [blocker, setBlocker] = useState<BlockerState>(unblockedState)
+  const allowNextNavigationRef = useRef(false)
   const dataRouterContext = useContext(UNSAFE_DataRouterContext)
 
   const isSamePathNavigation = blocker.state === 'blocked' && blocker.location?.pathname === window.location.pathname
@@ -53,6 +55,20 @@ export const UnsavedChangesProvider = ({
   const resetMessage = useCallback(() => {
     setMessage(defaultMessage)
   }, [defaultMessage])
+
+  const allowNextNavigation = useCallback(() => {
+    allowNextNavigationRef.current = true
+    setDirty(false)
+  }, [])
+
+  const shouldBlockNavigation = useCallback(() => {
+    if (!isDirty) return false
+    if (allowNextNavigationRef.current) {
+      allowNextNavigationRef.current = false
+      return false
+    }
+    return true
+  }, [isDirty])
 
   const handleConfirm = useCallback(() => {
     if (blocker.state === 'blocked') {
@@ -87,13 +103,14 @@ export const UnsavedChangesProvider = ({
       setDirty,
       setMessage,
       resetMessage,
+      allowNextNavigation,
     }),
-    [isDirty, message, resetMessage]
+    [allowNextNavigation, isDirty, message, resetMessage]
   )
 
   return (
     <UnsavedChangesContext.Provider value={value}>
-      {dataRouterContext ? <BlockerBridge shouldBlock={isDirty} onChange={setBlocker} /> : null}
+      {dataRouterContext ? <BlockerBridge shouldBlock={shouldBlockNavigation} onChange={setBlocker} /> : null}
       {children}
       <UnsavedChangesDialog
         open={showDialog}

--- a/frontend/src/components/unsavedChangesContext.ts
+++ b/frontend/src/components/unsavedChangesContext.ts
@@ -6,6 +6,7 @@ export type UnsavedChangesContextValue = {
   setDirty: (dirty: boolean) => void
   setMessage: (message: string) => void
   resetMessage: () => void
+  allowNextNavigation?: () => void
 }
 
 export const UnsavedChangesContext = createContext<UnsavedChangesContextValue | null>(null)

--- a/frontend/src/shared/types/data.ts
+++ b/frontend/src/shared/types/data.ts
@@ -489,17 +489,24 @@ export type TimeBound = {
 
 export type TimeBoundDetailsType = Prisma.now_tu_bound & { now_bau: TimeBoundUpdate[] }
 
-export type TimeBoundUpdate = Prisma.now_bau & { now_br: Prisma.now_br } & { updates: UpdateLog[] }
+export type TimeBoundUpdate = Prisma.now_bau & { now_br: TimeBoundReference[] } & { updates: UpdateLog[] }
 
 /* Time Unit */
 export type TimeUnitSequence = Prisma.now_tu_sequence
 
 export type TimeUnitUpdate = Prisma.now_tau & {
-  now_tr: Prisma.now_tr & { ref_ref: { ref_authors: string; ref_journal: string }[] }
+  now_tr: TimeUnitReference[]
 } & { updates: UpdateLog[] }
+
+export type TimeUnitUpdateSummary = Prisma.now_time_update & {
+  now_tau: TimeUnitUpdate | null
+  lower_bound_update: TimeBoundUpdate | null
+  upper_bound_update: TimeBoundUpdate | null
+}
 
 export type TimeUnitDetailsType = Prisma.now_time_unit & { now_tu_sequence: SequenceDetailsType } & {
   now_tau: Array<TimeUnitUpdate>
+  now_time_update: Array<TimeUnitUpdateSummary>
 } & {
   low_bound: Prisma.now_tu_bound
   up_bound: Prisma.now_tu_bound

--- a/frontend/src/tests/components/DetailView/DetailViewCancelEdit.test.tsx
+++ b/frontend/src/tests/components/DetailView/DetailViewCancelEdit.test.tsx
@@ -25,6 +25,7 @@ const timeUnitData = {
   tu_comment: '',
   now_tu_sequence: { sequence: 'seq-1', seq_name: 'Sequence 1' },
   now_tau: [],
+  now_time_update: [],
   up_bound: { bid: 1, b_name: 'Upper', age: 20, b_comment: '' },
   low_bound: { bid: 2, b_name: 'Lower', age: 10, b_comment: '' },
 } as unknown as TimeUnitDetailsType

--- a/frontend/src/tests/components/DetailView/DetailViewUnsavedPrompt.test.tsx
+++ b/frontend/src/tests/components/DetailView/DetailViewUnsavedPrompt.test.tsx
@@ -26,6 +26,7 @@ const timeUnitData = {
   tu_comment: '',
   now_tu_sequence: { sequence: 'seq-1', seq_name: 'Sequence 1' },
   now_tau: [],
+  now_time_update: [],
   up_bound: { bid: 1, b_name: 'Upper', age: 20, b_comment: '' },
   low_bound: { bid: 2, b_name: 'Lower', age: 10, b_comment: '' },
 } as unknown as TimeUnitDetailsType

--- a/frontend/src/tests/components/SpeciesWriteButton.test.tsx
+++ b/frontend/src/tests/components/SpeciesWriteButton.test.tsx
@@ -185,7 +185,7 @@ describe('WriteButton taxonomy handling', () => {
       expect(onWrite).toHaveBeenCalledTimes(1)
     })
 
-    expect(onWrite).toHaveBeenCalledWith(expect.objectContaining({ sp_comment: null }), expect.any(Function))
+    expect(onWrite).toHaveBeenCalledWith(expect.objectContaining({ sp_comment: null }), expect.any(Function), undefined)
     expect(setEditData).toHaveBeenCalledWith(expect.objectContaining({ sp_comment: null }))
   })
 


### PR DESCRIPTION
## Summary
- Load `now_time_update` summary rows for Time Unit details and hydrate linked `now_tau`, lower-bound `now_bau`, and upper-bound `now_bau` updates.
- Attach generic log rows to both direct Time Unit updates and linked Time Bound updates.
- Replace the Time Unit Updates tab with a Time Unit-specific view that shows linked update groups and details.
- Keep hydrated update-history data out of Time Unit write persistence.
- Add a focused API assertion for legacy `now_time_update` rows with linked bound updates.

## Root cause
The React Time Unit Updates tab was rendering only `now_tau`, while the legacy PHP view is based on `now_time_update`. `now_time_update` is a summary of a Time Unit create/update event and may point to a direct Time Unit update (`tuid`) plus lower/upper Time Bound updates (`lower_buid` / `upper_buid`). Rows with only bound update ids were invisible in the React path.

## Validation
- `npm run lint:backend`
- `npm run lint:frontend`
- `npm run tsc:backend`
- `npm run tsc:frontend`
- `git diff --check`
- Commit hook: `npm run lint` and `npm run tsc`

## Local test note
- Attempted `cd backend && DATABASE_URL=mysql://now_test:mariadb_password@127.0.0.1:3307/now_test LOG_DATABASE_URL=mysql://now_test:mariadb_password@127.0.0.1:3307/now_log_test DOTENV_CONFIG_PATH=../.test.env NODE_OPTIONS='-r dotenv/config' npx jest src/api-tests/timeUnit/timeUnitsFetch.test.ts --runInBand --config jest-config.js --detectOpenHandles --forceExit`.
- The run failed before assertions because the local test DB connection refused `127.0.0.1:3307`; the new regression assertion remains in the suite for CI/a healthy local DB.

Closes #563