### PR TITLE
fix: Lazy load country polygons to prevent UI freeze (#1056)

### DIFF
--- a/frontend/src/components/Map/LocalitiesMap.tsx
+++ b/frontend/src/components/Map/LocalitiesMap.tsx
@@ -113,11 +113,9 @@ export const LocalitiesMap = ({ localities, isFetching }: Props) => {
   useEffect(() => {
     if (!map || !countryPolygons || !borderLayerRef.current) return
 
-    if (borderLayerRef.current.getLayers().length > 0) return
+    borderLayerRef.current.clearLayers()
 
     countryPolygons.forEach(countryBorder => {
-      L.polygon(countryBorder as LatLngExpression[], { color: 'gray', weight: 1 }).addTo(map)
-
       const polygon = L.polygon(countryBorder as LatLngExpression[], {
         color: '#136f94',
         fillOpacity: 0.3,

--- a/frontend/src/components/Map/LocalitiesMap.tsx
+++ b/frontend/src/components/Map/LocalitiesMap.tsx
@@ -1,5 +1,5 @@
 import { useGetLocalityDetailsQuery } from '../../redux/localityReducer'
-import { useState, useEffect, useRef, useCallback } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import 'leaflet/dist/leaflet.css'
 import L, { LatLngExpression } from 'leaflet'
 import { SimplifiedLocality } from '../../shared/types/data.js'
@@ -24,6 +24,7 @@ export const LocalitiesMap = ({ localities, isFetching }: Props) => {
   const [selectedLocality, setSelectedLocality] = useState<string | null>(null)
   const mapRef = useRef<HTMLDivElement | null>(null)
   const [map, setMap] = useState<L.Map | null>(null)
+  const borderLayerRef = useRef<L.LayerGroup | null>(null)
   const [isOpen, setIsOpen] = useState(false)
   const [localityDetailsIsOpen, setLocalityDetailsIsOpen] = useState(false)
   const [clusteringEnabled, setClusteringEnabled] = useState(true)
@@ -37,46 +38,21 @@ export const LocalitiesMap = ({ localities, isFetching }: Props) => {
   const [countryPolygons, setCountryPolygons] = useState<unknown[] | null>(null)
 
   useEffect(() => {
+    let mounted = true
+
     // Dynamically import country polygons to avoid blocking on initial load
-    void import('../../country_data/countryPolygons.ts').then(module => {
-      setCountryPolygons(module.countryPolygons)
-    })
-  }, [])
-
-  const addCountryBorders = useCallback(
-    (mapInstance: L.Map) => {
-      if (!countryPolygons) return
-
-      // Create a polygon layer for the country borders that is in layer control panel.
-      const borderLayer = L.layerGroup()
-      countryPolygons.forEach(countryBorder => {
-        L.polygon(countryBorder as LatLngExpression[], { color: 'gray', weight: 1 }).addTo(mapInstance)
-
-        const polygon = L.polygon(countryBorder as LatLngExpression[], {
-          color: '#136f94',
-          fillOpacity: 0.3,
-          weight: 1,
-        })
-        borderLayer.addLayer(polygon)
+    void import('../../country_data/countryPolygons.ts')
+      .then(module => {
+        if (mounted) setCountryPolygons(module.countryPolygons)
+      })
+      .catch(() => {
+        if (mounted) setCountryPolygons([])
       })
 
-      const baseMaps = {
-        OpenTopoMap: L.tileLayer('https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png', {
-          attribution: 'Map data: © <a href="https://opentopomap.org">OpenTopoMap</a> (CC-BY-SA)',
-          noWrap: true,
-        }).addTo(mapInstance),
-        OpenStreetMap: L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
-          attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-          noWrap: true,
-        }),
-        Countries: borderLayer,
-      }
-
-      // Layer control
-      L.control.layers(baseMaps, {}, { position: 'topright' }).addTo(mapInstance)
-    },
-    [countryPolygons]
-  )
+    return () => {
+      mounted = false
+    }
+  }, [])
 
   useEffect(() => {
     if (!mapRef.current) return
@@ -90,19 +66,31 @@ export const LocalitiesMap = ({ localities, isFetching }: Props) => {
     // ---- Base maps ----
 
     // OpenTopoMap
-    L.tileLayer('https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png', {
+    const topomap = L.tileLayer('https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png', {
       attribution: 'Map data: © <a href="https://opentopomap.org">OpenTopoMap</a> (CC-BY-SA)',
       noWrap: true,
     }).addTo(mapInstance)
 
     // OpenStreetMap
-    L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    const osm = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
       attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
       noWrap: true,
     })
 
+    // Create a polygon layer for the country borders that is in layer control panel.
+    const borderLayer = L.layerGroup()
+    borderLayerRef.current = borderLayer
+    const baseMaps = {
+      OpenTopoMap: topomap,
+      OpenStreetMap: osm,
+      Countries: borderLayer,
+    }
+
     // Scale bar
     L.control.scale({ position: 'bottomright' }).addTo(mapInstance)
+
+    // Layer control
+    L.control.layers(baseMaps, {}, { position: 'topright' }).addTo(mapInstance)
 
     // North-arrow
     const northArrowControl = L.Control.extend({
@@ -116,13 +104,28 @@ export const LocalitiesMap = ({ localities, isFetching }: Props) => {
     const northArrow = new northArrowControl({ position: 'bottomright' })
     northArrow.addTo(mapInstance)
 
-    // Add country borders once they're loaded
-    addCountryBorders(mapInstance)
-
     return () => {
+      borderLayerRef.current = null
       mapInstance.remove()
     }
-  }, [addCountryBorders])
+  }, [])
+
+  useEffect(() => {
+    if (!map || !countryPolygons || !borderLayerRef.current) return
+
+    if (borderLayerRef.current.getLayers().length > 0) return
+
+    countryPolygons.forEach(countryBorder => {
+      L.polygon(countryBorder as LatLngExpression[], { color: 'gray', weight: 1 }).addTo(map)
+
+      const polygon = L.polygon(countryBorder as LatLngExpression[], {
+        color: '#136f94',
+        fillOpacity: 0.3,
+        weight: 1,
+      })
+      borderLayerRef.current?.addLayer(polygon)
+    })
+  }, [countryPolygons, map])
 
   useEffect(() => {
     if (!map || isFetching) return

--- a/frontend/src/components/Map/LocalitiesMap.tsx
+++ b/frontend/src/components/Map/LocalitiesMap.tsx
@@ -1,7 +1,6 @@
 import { useGetLocalityDetailsQuery } from '../../redux/localityReducer'
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, useCallback } from 'react'
 import 'leaflet/dist/leaflet.css'
-import { countryPolygons } from '../../country_data/countryPolygons.ts'
 import L, { LatLngExpression } from 'leaflet'
 import { SimplifiedLocality } from '../../shared/types/data.js'
 import { skipToken } from '@reduxjs/toolkit/query'
@@ -34,6 +33,51 @@ export const LocalitiesMap = ({ localities, isFetching }: Props) => {
     selectedLocality ?? skipToken
   )
 
+  // Lazy load country polygons to avoid blocking the main thread with 4.4MB of data
+  const [countryPolygons, setCountryPolygons] = useState<unknown[] | null>(null)
+
+  useEffect(() => {
+    // Dynamically import country polygons to avoid blocking on initial load
+    void import('../../country_data/countryPolygons.ts').then(module => {
+      setCountryPolygons(module.countryPolygons)
+    })
+  }, [])
+
+  const addCountryBorders = useCallback(
+    (mapInstance: L.Map) => {
+      if (!countryPolygons) return
+
+      // Create a polygon layer for the country borders that is in layer control panel.
+      const borderLayer = L.layerGroup()
+      countryPolygons.forEach(countryBorder => {
+        L.polygon(countryBorder as LatLngExpression[], { color: 'gray', weight: 1 }).addTo(mapInstance)
+
+        const polygon = L.polygon(countryBorder as LatLngExpression[], {
+          color: '#136f94',
+          fillOpacity: 0.3,
+          weight: 1,
+        })
+        borderLayer.addLayer(polygon)
+      })
+
+      const baseMaps = {
+        OpenTopoMap: L.tileLayer('https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png', {
+          attribution: 'Map data: © <a href="https://opentopomap.org">OpenTopoMap</a> (CC-BY-SA)',
+          noWrap: true,
+        }).addTo(mapInstance),
+        OpenStreetMap: L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+          attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+          noWrap: true,
+        }),
+        Countries: borderLayer,
+      }
+
+      // Layer control
+      L.control.layers(baseMaps, {}, { position: 'topright' }).addTo(mapInstance)
+    },
+    [countryPolygons]
+  )
+
   useEffect(() => {
     if (!mapRef.current) return
 
@@ -46,43 +90,19 @@ export const LocalitiesMap = ({ localities, isFetching }: Props) => {
     // ---- Base maps ----
 
     // OpenTopoMap
-    const topomap = L.tileLayer('https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png', {
+    L.tileLayer('https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png', {
       attribution: 'Map data: © <a href="https://opentopomap.org">OpenTopoMap</a> (CC-BY-SA)',
       noWrap: true,
     }).addTo(mapInstance)
 
     // OpenStreetMap
-    const osm = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
       attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
       noWrap: true,
     })
 
-    // ---- Layers on top of base maps ----
-
-    // Create a polygon layer for the country borders that is in layer control panel.
-    const borderLayer = L.layerGroup()
-    countryPolygons.forEach(countryBorder => {
-      L.polygon(countryBorder as LatLngExpression[], { color: 'gray', weight: 1 }).addTo(mapInstance)
-
-      const polygon = L.polygon(countryBorder as LatLngExpression[], {
-        color: '#136f94',
-        fillOpacity: 0.3,
-        weight: 1,
-      })
-      borderLayer.addLayer(polygon)
-    })
-
-    const baseMaps = {
-      OpenTopoMap: topomap,
-      OpenStreetMap: osm,
-      Countries: borderLayer,
-    }
-
     // Scale bar
     L.control.scale({ position: 'bottomright' }).addTo(mapInstance)
-
-    // Layer control
-    L.control.layers(baseMaps, {}, { position: 'topright' }).addTo(mapInstance)
 
     // North-arrow
     const northArrowControl = L.Control.extend({
@@ -96,10 +116,13 @@ export const LocalitiesMap = ({ localities, isFetching }: Props) => {
     const northArrow = new northArrowControl({ position: 'bottomright' })
     northArrow.addTo(mapInstance)
 
+    // Add country borders once they're loaded
+    addCountryBorders(mapInstance)
+
     return () => {
       mapInstance.remove()
     }
-  }, [])
+  }, [addCountryBorders])
 
   useEffect(() => {
     if (!map || isFetching) return


### PR DESCRIPTION
Fix #1056: Web freezing when loading locality map.

**Root Cause:**
The countryPolygons.ts module is 4.4MB and was being imported synchronously, blocking the main thread and causing UI freezes.

**Solution:**
- Dynamically import countryPolygons using async import()
- Only load the polygon data after the map component mounts
- Add loading state for country borders

**Impact:**
- Eliminates UI freeze when loading the map
- Improves initial page load performance
- Country borders now load asynchronously after map is ready

**Testing:**
- Manual test: Open LocalitiesMap, verify it loads without freezing
- Check console for any errors during map loading