### PR TITLE
fix: Temporarily remove phpmyadmin service from docker compose files (#1177)

### DIFF
--- a/docker-compose.anon.yml
+++ b/docker-compose.anon.yml
@@ -53,16 +53,17 @@ services:
       timeout: 5s
       retries: 3
 
-  phpmyadmin:
-    restart: always
-    image: phpmyadmin:5.2.1
-    environment:
-      PMA_ARBITRARY: 1
-      PMA_HOST: db-anon
-      PMA_PORT: 3306
-    ports:
-      - "8080:80"
-      - "9090:443"
+  # phpmyadmin service temporarily disabled - see issue #1177
+  # phpmyadmin:
+  #   restart: always
+  #   image: phpmyadmin:5.2.1
+  #   environment:
+  #     PMA_ARBITRARY: 1
+  #     PMA_HOST: db-anon
+  #     PMA_PORT: 3306
+  #   ports:
+  #     - "8080:80"
+  #     - "9090:443"
 
 volumes:
   nowdb-db-anon:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -45,16 +45,17 @@ services:
     ports:
       - 127.0.0.1:3307:3306
 
-  phpmyadmin:
-    restart: always
-    image: phpmyadmin:5.2.1
-    environment:
-      PMA_ARBITRARY: 1
-      PMA_HOST: db
-      PMA_PORT: 3306
-    ports:
-      - "8080:80"
-      - "9090:443"
+  # phpmyadmin service temporarily disabled - see issue #1177
+  # phpmyadmin:
+  #   restart: always
+  #   image: phpmyadmin:5.2.1
+  #   environment:
+  #     PMA_ARBITRARY: 1
+  #     PMA_HOST: db
+  #     PMA_PORT: 3306
+  #   ports:
+  #     - "8080:80"
+  #     - "9090:443"
 
 volumes:
   nowdb-db-dev:


### PR DESCRIPTION
Fix #1177: Docker tries to attach to non-existent containers causing npm run start:anon and npm run dev to fail.

**Solution:**
Temporarily commented out phpmyadmin service from docker-compose.anon.yml and docker-compose.dev.yml.

**Impact:**
- npm run start:anon and npm run dev will no longer fail due to phpmyadmin container issues
- phpMyAdmin will not be available until the root cause is fixed
- This is a workaround until issue #1178 can be investigated

**Files changed:**
- docker-compose.anon.yml
- docker-compose.dev.yml

**Next steps:**
Investigate the root cause in #1178: Figure out Docker problem with phpmyadmin service