### PR TITLE
[codex] Add occurrence row history

### DIFF
--- a/backend/src/services/locality.ts
+++ b/backend/src/services/locality.ts
@@ -21,6 +21,7 @@ import { validateCollectingMethodValues } from '../utils/validation/collectingMe
 import { buildPersonLookupByInitials, getPersonDisplayName, getPersonFromLookup } from './utils/person'
 import { getReferenceDetails } from './reference'
 import { addNullExactDateToReferenceJoins, referenceWithoutExactDateSelect } from './utils/referenceDate'
+import { getOccurrenceUpdatesForRows } from './occurrenceService'
 
 const normalizeNumberField = (value: unknown) => {
   if (typeof value === 'string') {
@@ -301,6 +302,13 @@ export const getLocalityDetails = async (id: number, user: User | undefined) => 
       if (!result.now_plr.find(proj => usersProjects.has(proj.pid))) throw new AccessError()
     }
   }
+
+  const occurrenceUpdatesByKey = await getOccurrenceUpdatesForRows(result.now_ls)
+  result.now_ls = result.now_ls.map(occurrence => ({
+    ...occurrence,
+    now_oau: (occurrenceUpdatesByKey.get(`${occurrence.lid}:${occurrence.species_id}`) ??
+      []) as unknown as LocalitySpeciesDetailsType['now_oau'],
+  }))
 
   const {
     now_time_unit_now_loc_bfa_minTonow_time_unit: minTimeUnit,

--- a/backend/src/services/occurrenceService.ts
+++ b/backend/src/services/occurrenceService.ts
@@ -111,6 +111,16 @@ const getOccurrenceLogRows = (rows: RawOccurrenceLogRow[], speciesPk: string): O
   return occurrenceRows
 }
 
+const getOccurrenceLogRowsForKey = (rows: RawOccurrenceLogRow[], lid: number, speciesId: number) => {
+  const lidPk = `${lid.toString().length}.${lid};`
+  const speciesPk = `${speciesId.toString().length}.${speciesId};`
+
+  return getOccurrenceLogRows(
+    rows.filter(row => isOccurrenceLogCandidate(row) && row.pk_data.includes(lidPk)),
+    speciesPk
+  )
+}
+
 type OccurrenceUpdate = {
   occ_date: Date | null
   occ_authorizer: string
@@ -118,6 +128,16 @@ type OccurrenceUpdate = {
   occ_comment: string
   references: AnyReference[]
   updates: OccurrenceLogRow[]
+}
+
+const OCCURRENCE_LOG_QUERY_BATCH_SIZE = 100
+
+const chunkArray = <T>(values: T[], size: number) => {
+  const chunks: T[][] = []
+  for (let index = 0; index < values.length; index += size) {
+    chunks.push(values.slice(index, index + size))
+  }
+  return chunks
 }
 
 const stringifyLogValue = (value: unknown) => {
@@ -170,18 +190,32 @@ const deduplicateOccurrenceUpdates = (updates: OccurrenceUpdate[]) => {
   return Array.from(deduplicated.values())
 }
 
-const getOccurrenceUpdates = async (lid: number, speciesId: number) => {
-  const lidPk = `${lid.toString().length}.${lid};`
-  const speciesPk = `${speciesId.toString().length}.${speciesId};`
+export const getOccurrenceUpdatesForRows = async (keys: Array<{ lid: number; species_id: number }>) => {
+  const uniqueKeys = Array.from(new Map(keys.map(key => [`${key.lid}:${key.species_id}`, key] as const)).values())
 
-  const candidateLogsRaw = await logDb.log.findMany({
-    where: {
-      table_name: 'now_ls',
-      pk_data: { contains: lidPk },
-    },
-  })
+  if (uniqueKeys.length === 0) return new Map<string, OccurrenceUpdate[]>()
 
-  const nowLsLogs = getOccurrenceLogRows(candidateLogsRaw, speciesPk)
+  const uniqueLidPks = Array.from(new Set(uniqueKeys.map(({ lid }) => `${lid.toString().length}.${lid};`)))
+  const candidateLogsRaw: RawOccurrenceLogRow[] = []
+
+  for (const lidPkBatch of chunkArray(uniqueLidPks, OCCURRENCE_LOG_QUERY_BATCH_SIZE)) {
+    candidateLogsRaw.push(
+      ...(await logDb.log.findMany({
+        where: {
+          table_name: 'now_ls',
+          OR: lidPkBatch.map(lidPk => ({ pk_data: { contains: lidPk } })),
+        },
+      }))
+    )
+  }
+
+  const logsByKey = new Map<string, OccurrenceLogRow[]>()
+
+  for (const { lid, species_id: speciesId } of uniqueKeys) {
+    logsByKey.set(`${lid}:${speciesId}`, getOccurrenceLogRowsForKey(candidateLogsRaw, lid, speciesId))
+  }
+
+  const nowLsLogs = Array.from(logsByKey.values()).flat()
 
   const luids = collectUniqueIds(nowLsLogs, 'luid')
   const suids = collectUniqueIds(nowLsLogs, 'suid')
@@ -217,47 +251,67 @@ const getOccurrenceUpdates = async (lid: number, speciesId: number) => {
       : Promise.resolve([]),
   ])
 
+  const localityUpdateById = new Map(localityUpdates.map(update => [update.luid, update] as const))
+  const speciesUpdateById = new Map(speciesUpdates.map(update => [update.suid, update] as const))
+
   const peopleLookup = await buildPersonLookupByInitials([
     ...localityUpdates.flatMap(update => [update.lau_authorizer, update.lau_coordinator]),
     ...speciesUpdates.flatMap(update => [update.sau_authorizer, update.sau_coordinator]),
   ])
 
-  const occurrenceUpdates = deduplicateOccurrenceUpdates([
-    ...localityUpdates.map(update => ({
-      occ_date: update.lau_date,
-      occ_authorizer: getPersonDisplayName(
-        getPersonFromLookup(peopleLookup, update.lau_authorizer),
-        update.lau_authorizer
-      ),
-      occ_coordinator: getPersonDisplayName(
-        getPersonFromLookup(peopleLookup, update.lau_coordinator),
-        update.lau_coordinator
-      ),
-      occ_comment: update.lau_comment ?? '',
-      references: addNullExactDateToReferenceJoins(update.now_lr) as unknown as AnyReference[],
-      updates: nowLsLogs.filter(logRow => logRow.luid === update.luid),
-    })),
-    ...speciesUpdates.map(update => ({
-      occ_date: update.sau_date,
-      occ_authorizer: getPersonDisplayName(
-        getPersonFromLookup(peopleLookup, update.sau_authorizer),
-        update.sau_authorizer
-      ),
-      occ_coordinator: getPersonDisplayName(
-        getPersonFromLookup(peopleLookup, update.sau_coordinator),
-        update.sau_coordinator
-      ),
-      occ_comment: update.sau_comment ?? '',
-      references: addNullExactDateToReferenceJoins(update.now_sr) as unknown as AnyReference[],
-      updates: nowLsLogs.filter(logRow => logRow.suid === update.suid),
-    })),
-  ])
+  const occurrenceUpdatesByKey = new Map<string, OccurrenceUpdate[]>()
 
-  return occurrenceUpdates.sort((a, b) => {
-    const timeA = a.occ_date ? new Date(a.occ_date).getTime() : 0
-    const timeB = b.occ_date ? new Date(b.occ_date).getTime() : 0
-    return timeB - timeA
-  })
+  for (const [key, logs] of logsByKey) {
+    const occurrenceUpdates = deduplicateOccurrenceUpdates([
+      ...Array.from(new Set(logs.map(log => log.luid).filter((luid): luid is number => luid !== null)))
+        .map(luid => localityUpdateById.get(luid))
+        .filter((update): update is NonNullable<typeof update> => Boolean(update))
+        .map(update => ({
+          occ_date: update.lau_date,
+          occ_authorizer: getPersonDisplayName(
+            getPersonFromLookup(peopleLookup, update.lau_authorizer),
+            update.lau_authorizer
+          ),
+          occ_coordinator: getPersonDisplayName(
+            getPersonFromLookup(peopleLookup, update.lau_coordinator),
+            update.lau_coordinator
+          ),
+          occ_comment: update.lau_comment ?? '',
+          references: addNullExactDateToReferenceJoins(update.now_lr) as unknown as AnyReference[],
+          updates: logs.filter(logRow => logRow.luid === update.luid),
+        })),
+      ...Array.from(new Set(logs.map(log => log.suid).filter((suid): suid is number => suid !== null)))
+        .map(suid => speciesUpdateById.get(suid))
+        .filter((update): update is NonNullable<typeof update> => Boolean(update))
+        .map(update => ({
+          occ_date: update.sau_date,
+          occ_authorizer: getPersonDisplayName(
+            getPersonFromLookup(peopleLookup, update.sau_authorizer),
+            update.sau_authorizer
+          ),
+          occ_coordinator: getPersonDisplayName(
+            getPersonFromLookup(peopleLookup, update.sau_coordinator),
+            update.sau_coordinator
+          ),
+          occ_comment: update.sau_comment ?? '',
+          references: addNullExactDateToReferenceJoins(update.now_sr) as unknown as AnyReference[],
+          updates: logs.filter(logRow => logRow.suid === update.suid),
+        })),
+    ]).sort((a, b) => {
+      const timeA = a.occ_date ? new Date(a.occ_date).getTime() : 0
+      const timeB = b.occ_date ? new Date(b.occ_date).getTime() : 0
+      return timeB - timeA
+    })
+
+    occurrenceUpdatesByKey.set(key, occurrenceUpdates)
+  }
+
+  return occurrenceUpdatesByKey
+}
+
+const getOccurrenceUpdates = async (lid: number, speciesId: number) => {
+  const updatesByKey = await getOccurrenceUpdatesForRows([{ lid, species_id: speciesId }])
+  return updatesByKey.get(`${lid}:${speciesId}`) ?? []
 }
 
 export const getOccurrenceByCompositeKey = async (lid: number, speciesId: number, user?: User) => {

--- a/backend/src/services/species.ts
+++ b/backend/src/services/species.ts
@@ -7,6 +7,7 @@ import { logDb, nowDb } from '../utils/db'
 import { getReferenceDetails } from './reference'
 import { buildPersonLookupByInitials, getPersonDisplayName, getPersonFromLookup } from './utils/person'
 import { getIdsOfUsersProjects } from './locality'
+import { getOccurrenceUpdatesForRows } from './occurrenceService'
 
 const TAXONOMIC_FIELDS: Array<keyof Prisma.com_species> = ['genus_name', 'species_name', 'unique_identifier']
 
@@ -236,7 +237,13 @@ export const getSpeciesDetails = async (id: number, user?: User) => {
   })
 
   const filteredLocalities = await filterSpeciesLocalitiesByUser(result.now_ls as SpeciesDetailsType['now_ls'], user)
-  const sanitizedLocalities = stripLocalityProjectLinks(filteredLocalities)
+  const occurrenceUpdatesByKey = await getOccurrenceUpdatesForRows(filteredLocalities)
+  const localitiesWithOccurrenceUpdates = filteredLocalities.map(occurrence => ({
+    ...occurrence,
+    now_oau: (occurrenceUpdatesByKey.get(`${occurrence.lid}:${occurrence.species_id}`) ??
+      []) as unknown as SpeciesDetailsType['now_ls'][number]['now_oau'],
+  }))
+  const sanitizedLocalities = stripLocalityProjectLinks(localitiesWithOccurrenceUpdates)
 
   return fixBigInt({ ...result, now_ls: sanitizedLocalities, com_taxa_synonym: synonyms || [] }) as SpeciesDetailsType
 }

--- a/frontend/src/components/DetailView/common/FieldUpdateHistory.tsx
+++ b/frontend/src/components/DetailView/common/FieldUpdateHistory.tsx
@@ -9,8 +9,8 @@ type UpdateContainer = Record<string, unknown> & {
   updates: UpdateLog[]
 }
 
-type FieldUpdate = {
-  log: UpdateLog
+type HistoryUpdate = {
+  logs: UpdateLog[]
   container: UpdateContainer
 }
 
@@ -52,12 +52,12 @@ const collectUpdateContainers = (value: unknown, seen = new Set<unknown>()): Upd
   return containers
 }
 
-const getFieldUpdates = (data: unknown, field: string): FieldUpdate[] =>
+const getFieldUpdates = (data: unknown, field: string): HistoryUpdate[] =>
   collectUpdateContainers(data).flatMap(container =>
     container.updates
       .filter(log => log.column_name === field)
       .map(log => ({
-        log,
+        logs: [log],
         container,
       }))
   )
@@ -98,38 +98,37 @@ const getEntryUpdates = (
   columnName: string | undefined,
   rowValue: unknown,
   pkValues: unknown[]
-): FieldUpdate[] => {
+): HistoryUpdate[] => {
   const encodedPkSegments = getEncodedPkSegments(pkValues)
   const fallbackPkSegment = getEncodedPkSegment(rowValue)
 
-  return collectUpdateContainers(data).flatMap(container =>
-    container.updates
-      .filter(log => {
-        if (log.table_name !== tableName) return false
+  const updates = collectUpdateContainers(data).flatMap(container => {
+    const logs = container.updates.filter(log => {
+      if (log.table_name !== tableName) return false
 
-        const pkData = getPkData(log)
-        const pkDataMatches =
-          typeof pkData === 'string' && encodedPkSegments.length > 0
-            ? encodedPkSegments.every(segment => pkData.includes(segment))
-            : false
-        if (pkDataMatches) return true
-        if (typeof pkData === 'string' && encodedPkSegments.length > 0) return false
+      const pkData = getPkData(log)
+      const pkDataMatches =
+        typeof pkData === 'string' && encodedPkSegments.length > 0
+          ? encodedPkSegments.every(segment => pkData.includes(segment))
+          : false
+      if (pkDataMatches) return true
+      if (typeof pkData === 'string' && encodedPkSegments.length > 0) return false
 
-        const fallbackPkDataMatches =
-          typeof pkData === 'string' && encodedPkSegments.length === 0 && fallbackPkSegment
-            ? pkData.includes(fallbackPkSegment)
-            : false
-        if (fallbackPkDataMatches) return true
+      const fallbackPkDataMatches =
+        typeof pkData === 'string' && encodedPkSegments.length === 0 && fallbackPkSegment
+          ? pkData.includes(fallbackPkSegment)
+          : false
+      if (fallbackPkDataMatches) return true
 
-        if (columnName && log.column_name !== columnName) return false
+      if (columnName && log.column_name !== columnName) return false
 
-        return valuesMatch(log.new_data, rowValue) || valuesMatch(log.old_data, rowValue)
-      })
-      .map(log => ({
-        log,
-        container,
-      }))
-  )
+      return valuesMatch(log.new_data, rowValue) || valuesMatch(log.old_data, rowValue)
+    })
+
+    return logs.length > 0 ? [{ logs, container }] : []
+  })
+
+  return deduplicateHistoryUpdates(updates)
 }
 
 const formatValue = (value: unknown): string => {
@@ -176,10 +175,56 @@ const collectReferences = (value: unknown, seen = new Set<unknown>()): AnyRefere
     .flatMap(([, nestedValue]) => collectReferences(nestedValue, seen))
 }
 
+const getLogSignature = (log: UpdateLog) =>
+  [
+    formatValue(log.table_name),
+    formatValue(log.column_name),
+    formatValue(log.log_action),
+    formatValue(getPkData(log)),
+    formatValue(log.old_data),
+    formatValue(log.new_data),
+  ].join('|')
+
+const getReferencesSignature = (container: UpdateContainer) =>
+  collectReferences(container)
+    .map(reference => formatValue(reference.rid))
+    .sort()
+    .join(',')
+
+const getHistoryUpdateSignature = ({ logs, container }: HistoryUpdate) =>
+  [
+    formatDate(getDate(container)),
+    formatValue(getEditor(container)),
+    formatValue(getCoordinator(container)),
+    formatValue(getComment(container)),
+    getReferencesSignature(container),
+    [...logs].map(getLogSignature).sort().join('||'),
+  ].join('\n')
+
+const deduplicateHistoryUpdates = (updates: HistoryUpdate[]) => {
+  const seen = new Set<string>()
+  return updates.filter(update => {
+    const signature = getHistoryUpdateSignature(update)
+    if (seen.has(signature)) return false
+    seen.add(signature)
+    return true
+  })
+}
+
 const formatAction = (action: number | null | undefined) => {
   if (action === 1) return 'Delete'
   if (action === 3) return 'Update'
   return 'Add'
+}
+
+const formatActions = (logs: UpdateLog[]) => {
+  const actions = Array.from(new Set(logs.map(log => formatAction(log.log_action))))
+  return actions.join(', ')
+}
+
+const formatTables = (logs: UpdateLog[]) => {
+  const tables = Array.from(new Set(logs.map(log => formatValue(log.table_name)).filter(Boolean)))
+  return tables.join(', ')
 }
 
 const UpdateHistoryPopover = ({
@@ -194,7 +239,7 @@ const UpdateHistoryPopover = ({
   title: string
   tooltip: string
   ariaLabel: string
-  updates: FieldUpdate[]
+  updates: HistoryUpdate[]
   onOpen?: (event: MouseEvent<HTMLElement>) => void
 }) => {
   const [anchorElement, setAnchorElement] = useState<HTMLElement | null>(null)
@@ -236,10 +281,11 @@ const UpdateHistoryPopover = ({
           <Typography variant="subtitle1" component="h2">
             {title}
           </Typography>
-          {updates.map(({ log, container }, index) => {
+          {updates.map(({ logs, container }, index) => {
+            const primaryLog = logs[0]
             const references = collectReferences(container)
             return (
-              <Card key={`${index}-${log.log_id ?? ''}-${log.column_name ?? idPrefix}`} sx={{ p: 1.5 }}>
+              <Card key={`${index}-${primaryLog.log_id ?? ''}-${primaryLog.column_name ?? idPrefix}`} sx={{ p: 1.5 }}>
                 <Typography variant="body2">
                   <b>Date:</b> {formatDate(getDate(container))}
                 </Typography>
@@ -250,17 +296,37 @@ const UpdateHistoryPopover = ({
                   <b>Coordinator:</b> {formatValue(getCoordinator(container))}
                 </Typography>
                 <Typography variant="body2">
-                  <b>Action:</b> {formatAction(log.log_action)}
+                  <b>Action:</b> {formatActions(logs)}
                 </Typography>
                 <Typography variant="body2">
-                  <b>Table:</b> {formatValue(log.table_name)}
+                  <b>Table:</b> {formatTables(logs)}
                 </Typography>
-                <Typography variant="body2">
-                  <b>Before:</b> {log.old_data ?? ''}
-                </Typography>
-                <Typography variant="body2">
-                  <b>After:</b> {log.new_data ?? ''}
-                </Typography>
+                {logs.length === 1 ? (
+                  <>
+                    <Typography variant="body2">
+                      <b>Before:</b> {logs[0].old_data ?? ''}
+                    </Typography>
+                    <Typography variant="body2">
+                      <b>After:</b> {logs[0].new_data ?? ''}
+                    </Typography>
+                  </>
+                ) : (
+                  <Box>
+                    <Typography variant="body2">
+                      <b>Changes:</b>
+                    </Typography>
+                    {logs.map((log, logIndex) => (
+                      <Typography
+                        key={`${logIndex}-${log.log_id ?? ''}-${log.column_name ?? ''}`}
+                        variant="body2"
+                        sx={{ pl: 1 }}
+                      >
+                        <b>{formatValue(log.column_name)}:</b> {formatValue(log.old_data)} -&gt;{' '}
+                        {formatValue(log.new_data)}
+                      </Typography>
+                    ))}
+                  </Box>
+                )}
                 {getComment(container) ? (
                   <Typography variant="body2">
                     <b>Comment:</b> {formatValue(getComment(container))}

--- a/frontend/src/components/Locality/Tabs/OccurrencesTab.tsx
+++ b/frontend/src/components/Locality/Tabs/OccurrencesTab.tsx
@@ -16,6 +16,7 @@ import {
   exportOccurrenceMapSvg,
   getUniqueLocalityOccurrenceMapExportLocalities,
 } from '@/components/Species/localitySpeciesMapExport'
+import { EntryUpdateHistory } from '@/components/DetailView/common/FieldUpdateHistory'
 
 const hasMesowearScoreInputs = (row: LocalitySpecies) => {
   return (
@@ -258,6 +259,15 @@ export const OccurrencesTab = () => {
         getDetailPath={row => `/occurrence/${row.lid}/${row.species_id}`}
         kmlExport={kmlExport}
         svgExport={svgExport}
+        renderReadRowActions={({ row }) => (
+          <EntryUpdateHistory
+            row={row.original}
+            label={`occurrence ${row.original.lid}/${row.original.species_id}`}
+            tableName="now_ls"
+            getRowValue={occurrence => occurrence.species_id}
+            getPkValues={occurrence => [occurrence.lid, occurrence.species_id]}
+          />
+        )}
       />
     </Grouped>
   )

--- a/frontend/src/components/Species/Tabs/LocalitySpeciesTab.tsx
+++ b/frontend/src/components/Species/Tabs/LocalitySpeciesTab.tsx
@@ -17,6 +17,7 @@ import {
   exportOccurrenceMapSvg,
   getUniqueSpeciesLocalityMapExportLocalities,
 } from '../localitySpeciesMapExport'
+import { EntryUpdateHistory } from '@/components/DetailView/common/FieldUpdateHistory'
 
 const hasMesowearScoreInputs = (row: SpeciesLocality) => {
   return (
@@ -244,6 +245,15 @@ export const LocalitySpeciesTab = () => {
         checkRowRestriction={row => Boolean(row.now_loc?.loc_status)}
         kmlExport={kmlExport}
         svgExport={svgExport}
+        renderReadRowActions={({ row }) => (
+          <EntryUpdateHistory
+            row={row.original}
+            label={`occurrence ${row.original.lid}/${row.original.species_id}`}
+            tableName="now_ls"
+            getRowValue={occurrence => occurrence.lid}
+            getPkValues={occurrence => [occurrence.lid, occurrence.species_id]}
+          />
+        )}
       />
     </Grouped>
   )

--- a/frontend/src/shared/types/data.ts
+++ b/frontend/src/shared/types/data.ts
@@ -19,10 +19,14 @@ export type SedimentaryStructureValues = Prisma.now_ss_values
 export type CollectingMethod = Prisma.now_coll_meth
 export type CollectingMethodValues = Prisma.now_coll_meth_values
 export type LocalityProject = Prisma.now_plr & { now_proj: Prisma.now_proj }
-export type LocalitySpecies = FixBigInt<Prisma.now_ls> & { com_species: SpeciesType }
-export type LocalitySpeciesDetailsType = FixBigInt<Prisma.now_ls> & { com_species: SpeciesDetailsType }
+export type LocalitySpecies = FixBigInt<Prisma.now_ls> & { com_species: SpeciesType; now_oau?: OccurrenceUpdate[] }
+export type LocalitySpeciesDetailsType = FixBigInt<Prisma.now_ls> & {
+  com_species: SpeciesDetailsType
+  now_oau?: OccurrenceUpdate[]
+}
 export type SpeciesLocality = FixBigInt<Prisma.now_ls> & {
   now_loc: Prisma.now_loc
+  now_oau?: OccurrenceUpdate[]
   // Explicitly required in the Species locality payload because MW Score is
   // calculated client-side from these values in the occurrence table.
   mw_scale_min: number | null

--- a/frontend/src/tests/components/DetailView/FieldUpdateHistory.test.tsx
+++ b/frontend/src/tests/components/DetailView/FieldUpdateHistory.test.tsx
@@ -69,6 +69,62 @@ const detailData = {
       ],
     },
   ],
+  now_oau: [
+    {
+      occ_date: '2026-06-04',
+      occ_authorizer: 'ED',
+      occ_coordinator: 'CO',
+      occ_comment: 'Occurrence row changed',
+      references: [reference],
+      updates: [
+        {
+          log_id: 6,
+          table_name: 'now_ls',
+          pk_data: '3.100;3.200;',
+          column_name: 'lid',
+          log_action: 3,
+          old_data: '100',
+          new_data: '101',
+        },
+        {
+          log_id: 7,
+          table_name: 'now_ls',
+          pk_data: '3.100;3.200;',
+          column_name: 'species_id',
+          log_action: 3,
+          old_data: '200',
+          new_data: '201',
+        },
+      ],
+    },
+    {
+      occ_date: '2026-06-04',
+      occ_authorizer: 'ED',
+      occ_coordinator: 'CO',
+      occ_comment: 'Occurrence row changed',
+      references: [reference],
+      updates: [
+        {
+          log_id: 8,
+          table_name: 'now_ls',
+          pk_data: '3.100;3.200;',
+          column_name: 'lid',
+          log_action: 3,
+          old_data: '100',
+          new_data: '101',
+        },
+        {
+          log_id: 9,
+          table_name: 'now_ls',
+          pk_data: '3.100;3.200;',
+          column_name: 'species_id',
+          log_action: 3,
+          old_data: '200',
+          new_data: '201',
+        },
+      ],
+    },
+  ],
   now_sau: [
     {
       sau_date: '2026-05-29',
@@ -167,14 +223,39 @@ describe('FieldUpdateHistory', () => {
     await user.click(screen.getByLabelText('Show entry history for sedimentary structure cross-bedding'))
 
     expect(screen.getByRole('heading', { name: 'sedimentary structure cross-bedding entry history' })).toBeTruthy()
-    expect(screen.getAllByText('Added sedimentary structure')).toHaveLength(2)
-    expect(screen.getAllByText(/Field update reference/)).toHaveLength(2)
+    expect(screen.getAllByText('Added sedimentary structure')).toHaveLength(1)
+    expect(screen.getAllByText(/Field update reference/)).toHaveLength(1)
     const tableRow = screen.getAllByText('Table:')[0].closest('p')
     expect(tableRow).toBeTruthy()
     expect(within(tableRow as HTMLElement).getByText('now_ss')).toBeInTheDocument()
-    expect(screen.getByText('old row comment')).toBeInTheDocument()
-    expect(screen.getByText('new row comment')).toBeInTheDocument()
+    expect(screen.getByText('ss_comment:').closest('p')).toHaveTextContent('old row comment -> new row comment')
     expect(screen.queryByText('101')).not.toBeInTheDocument()
+  })
+
+  it('groups duplicate occurrence row update logs into one history entry', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <MemoryRouter>
+        <DetailContext.Provider value={contextValue}>
+          <EntryUpdateHistory
+            row={{ lid: 100, species_id: 200 }}
+            label="occurrence 100/200"
+            tableName="now_ls"
+            getRowValue={row => row.species_id}
+            getPkValues={row => [row.lid, row.species_id]}
+          />
+        </DetailContext.Provider>
+      </MemoryRouter>
+    )
+
+    await user.click(screen.getByLabelText('Show entry history for occurrence 100/200'))
+
+    expect(screen.getByRole('heading', { name: 'occurrence 100/200 entry history' })).toBeTruthy()
+    expect(screen.getAllByText('Occurrence row changed')).toHaveLength(1)
+    expect(screen.getAllByText(/Field update reference/)).toHaveLength(1)
+    expect(screen.getByText('lid:').closest('p')).toHaveTextContent('100 -> 101')
+    expect(screen.getByText('species_id:').closest('p')).toHaveTextContent('200 -> 201')
   })
 
   it('uses a safe popover id for entry values with spaces or punctuation', async () => {


### PR DESCRIPTION
## Summary
- Add batched backend enrichment for occurrence row history using the existing occurrence update merge logic.
- Attach `now_oau` history arrays to `now_ls` rows in locality and species detail payloads.
- Add occurrence row history icons to locality and species occurrence list tabs using the shared entry-history popover.
- Extend frontend occurrence row types to allow optional `now_oau` on list rows.

## Root Cause / Context
Occurrence rows are stored as `now_ls` relation records and their log rows can be associated with both locality update entries (`luid`) and species update entries (`suid`). The occurrence detail endpoint already knew how to merge those logs into `now_oau`, but the locality/species occurrence list rows did not receive that enriched history, so the row-level popover from #1191 had no complete occurrence history to show.

## Validation
- `npm run tsc:backend`
- `npm run tsc:frontend`
- `cd frontend && npm test -- --runTestsByPath src/tests/components/DetailView/FieldUpdateHistory.test.tsx --runInBand`
- `npm run lint:frontend`
- `npm run lint:backend`
- Commit hook also ran root `npm run lint` and root `npm run tsc` successfully.

Closes #1192