### PR TITLE
[codex] Fix generated password validation

### DIFF
--- a/backend/src/unit-tests/validatePassword.test.ts
+++ b/backend/src/unit-tests/validatePassword.test.ts
@@ -8,6 +8,10 @@ describe('Password validation utils', () => {
   it('Accepts correct password with symbols', () => {
     expect(validatePassword('thisisav~!%ali&dpas$sword').isValid).toBeTruthy()
   })
+  it('Accepts generated password symbols', () => {
+    expect(validatePassword('valid^password').isValid).toBeTruthy()
+    expect(validatePassword('valid?password').isValid).toBeTruthy()
+  })
   it('Rejects invalid password with unsupported symbols in the middle', () => {
     expect(validatePassword('thisisav~%a€li&dpas$sword').isValid).toBeFalsy()
   })

--- a/backend/src/utils/validatePassword.ts
+++ b/backend/src/utils/validatePassword.ts
@@ -5,7 +5,7 @@ export interface PasswordValidationResult {
 
 export const validatePassword = (password: string): PasswordValidationResult => {
   if (password.length < 8) return { isValid: false, error: 'Password must be at least 8 characters long' }
-  if (!/^[0-9A-Za-z$%&~!]+$/.test(password))
+  if (!/^[0-9A-Za-z^?$%&~!]+$/.test(password))
     return {
       isValid: false,
       error: 'Password must only contain characters a-z, A-Z, 0-9 and ^?$%&~!',

--- a/frontend/src/hooks/usePasswordValidation.ts
+++ b/frontend/src/hooks/usePasswordValidation.ts
@@ -19,7 +19,7 @@ export const usePasswordValidation = () => {
         return { isValid: false, error: requirements[0] }
       }
 
-      if (!/^[0-9A-Za-z$%&~!]+$/.test(password)) {
+      if (!/^[0-9A-Za-z^?$%&~!]+$/.test(password)) {
         return { isValid: false, error: requirements[1] }
       }
 


### PR DESCRIPTION
## Summary
- Confirmed #730 is still relevant in the narrowed form from the issue comment: rights management works, but setting/generated passwords can fail.
- Align backend and frontend password validation with the documented/generated allowed characters by accepting `^` and `?`.
- Add backend unit coverage for generated-password symbols.

## Root Cause / Context
The admin user modal can generate passwords using `^` and `?`, and both frontend/backend messages said those characters were allowed. The actual validation regex on both sides omitted them, so generated or manually-set admin passwords containing those characters were rejected.

## Validation
- `cd backend && npx jest src/unit-tests/validatePassword.test.ts --runInBand --config jest-config.js`
- `npm run lint:backend`
- `npm run lint:frontend`
- `npm run tsc:backend`
- `npm run tsc:frontend`
- Commit hook also ran root `npm run lint` and root `npm run tsc` successfully.

Closes #730