### PR TITLE
Fix tables showing incorrect amount of pages, and some other table issues

### DIFF
--- a/frontend/src/components/CrossSearch/CrossSearchTable.tsx
+++ b/frontend/src/components/CrossSearch/CrossSearchTable.tsx
@@ -16,6 +16,7 @@ import {
   exportOccurrenceMapSvg,
   getUniqueCrossSearchMapExportLocalities,
 } from '@/components/Species/localitySpeciesMapExport'
+import { Box } from '@mui/material'
 
 const LocalitiesMap = lazy(async () => {
   const module = await import('../Map/LocalitiesMap')
@@ -1119,11 +1120,11 @@ export const CrossSearchTable = ({ selectorFn }: { selectorFn?: (newObject: Cros
         isError={isError}
         error={error}
         renderExtraExportMenuItems={handleClose => (
-          <>
+          <Box>
             <OccurrenceDwcExportMenuItem handleClose={handleClose} />
             <OccurrenceDwcDpExportMenuItem handleClose={handleClose} />
             <OccurrenceFullDarwinCoreExportMenuItem handleClose={handleClose} />
-          </>
+          </Box>
         )}
       />
     </>

--- a/frontend/src/components/TableView/TableView.tsx
+++ b/frontend/src/components/TableView/TableView.tsx
@@ -733,15 +733,13 @@ export const TableView = <T extends MRT_RowData>({
   ])
 
   useEffect(() => {
-    if (serverSidePagination) {
-      if (data && data.length > 0) {
-        setRowCount(data[0].full_count as number)
-      } else {
-        setRowCount(0)
-      }
+    if (!serverSidePagination) return
+    if (data && data.length > 0) {
+      setRowCount(data[0].full_count as number)
+    } else {
+      setRowCount(0)
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data])
+  }, [data, serverSidePagination])
 
   useEffect(() => {
     if (selectorFn) {

--- a/frontend/src/components/TableView/TableView.tsx
+++ b/frontend/src/components/TableView/TableView.tsx
@@ -484,10 +484,6 @@ export const TableView = <T extends MRT_RowData>({
     document.title = `${title}`
   }
 
-  if (data && data.length > 0) {
-    if (serverSidePagination) setRowCount(data[0].full_count as number)
-  }
-
   const resolveDetailPath = (row: T) => {
     if (getDetailPath) return getDetailPath(row)
     return `/${url}/${row[idFieldName] as string | number}`
@@ -672,8 +668,8 @@ export const TableView = <T extends MRT_RowData>({
     onPaginationChange: setPagination,
     manualPagination: serverSidePagination,
     manualSorting: serverSidePagination,
-    rowCount: rowCount,
-    autoResetPageIndex: true,
+    rowCount: serverSidePagination ? rowCount : undefined,
+    autoResetPageIndex: !serverSidePagination,
     positionPagination: paginationPlacement ?? (selectorFn ? 'top' : 'both'),
     paginationDisplayMode: 'pages',
     muiTablePaperProps: {
@@ -738,12 +734,27 @@ export const TableView = <T extends MRT_RowData>({
   ])
 
   useEffect(() => {
+    if (serverSidePagination) {
+      if (data && data.length > 0) {
+        setRowCount(data[0].full_count as number)
+      } else {
+        setRowCount(0)
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data])
+
+  useEffect(() => {
     if (selectorFn) {
       return
     }
     setIdList(table.getPrePaginationRowModel().rows.map(row => row.original[idFieldName] as string))
-    setRowCount(table.getPrePaginationRowModel().rows.length)
-
+    // resets pagination when filters or sorting change
+    if (serverSidePagination) {
+      setPagination(selectorFn ? defaultPaginationSmall : defaultPagination)
+    } else {
+      setRowCount(table.getPrePaginationRowModel().rows.length)
+    }
     // Don't put setIdList in the dependency array: it will cause re-render loop.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [table, columnFilters, sorting])

--- a/frontend/src/components/TableView/TableView.tsx
+++ b/frontend/src/components/TableView/TableView.tsx
@@ -746,11 +746,9 @@ export const TableView = <T extends MRT_RowData>({
       return
     }
     setIdList(table.getPrePaginationRowModel().rows.map(row => row.original[idFieldName] as string))
-    // resets pagination when filters or sorting change
     if (serverSidePagination) {
+      // resets pagination when filters or sorting change
       setPagination(selectorFn ? defaultPaginationSmall : defaultPagination)
-    } else {
-      setRowCount(table.getPrePaginationRowModel().rows.length)
     }
     // Don't put setIdList in the dependency array: it will cause re-render loop.
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/src/components/TableView/TableView.tsx
+++ b/frontend/src/components/TableView/TableView.tsx
@@ -15,7 +15,7 @@ import {
 import { Alert, Box, CircularProgress, Paper, Tooltip } from '@mui/material'
 import type { FetchBaseQueryError } from '@reduxjs/toolkit/query'
 import type { SerializedError } from '@reduxjs/toolkit'
-import type { FilterFn } from '@tanstack/table-core'
+import { type FilterFn } from '@tanstack/table-core'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { ActionComponent } from './ActionComponent'
 import { usePageContext } from '../Page'
@@ -249,6 +249,7 @@ export const TableView = <T extends MRT_RowData>({
   } = usePageContext()
   const [columnFilters, setColumnFilters] = useState<MRT_ColumnFiltersState>([])
   const [sorting, setSorting] = useState<MRT_SortingState>(defaultSorting ?? [])
+  const [rowCount, setRowCount] = useState(data ? data.length : 0)
   const navigate = useNavigate()
   const [pagination, setPagination] = useState<MRT_PaginationState>(
     selectorFn ? defaultPaginationSmall : defaultPagination
@@ -483,10 +484,8 @@ export const TableView = <T extends MRT_RowData>({
     document.title = `${title}`
   }
 
-  let rowCount = undefined
   if (data && data.length > 0) {
-    if (serverSidePagination) rowCount = data[0].full_count as number
-    else rowCount = data.length
+    if (serverSidePagination) setRowCount(data[0].full_count as number)
   }
 
   const resolveDetailPath = (row: T) => {
@@ -743,6 +742,7 @@ export const TableView = <T extends MRT_RowData>({
       return
     }
     setIdList(table.getPrePaginationRowModel().rows.map(row => row.original[idFieldName] as string))
+    setRowCount(table.getPrePaginationRowModel().rows.length)
 
     // Don't put setIdList in the dependency array: it will cause re-render loop.
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/src/components/TableView/TableView.tsx
+++ b/frontend/src/components/TableView/TableView.tsx
@@ -723,7 +723,6 @@ export const TableView = <T extends MRT_RowData>({
   }, [
     columnFilters,
     sorting,
-    pagination,
     columnVisibility,
     selectorFn,
     table,


### PR DESCRIPTION
Fixes #817. Also fixes:
- Occurences table navigating back to first page as soon as user tries to go to another page
- console error related to the menu bar of the Occurences table
- rerender loop in TableView caused by a dependency inside a useEffect.