### PR TITLE
Fix navigation inside tabs with a tableview replacing all query param…

### DIFF
--- a/frontend/src/components/TableView/TableView.tsx
+++ b/frontend/src/components/TableView/TableView.tsx
@@ -421,7 +421,7 @@ export const TableView = <T extends MRT_RowData>({
 
   const buildTableStateUrl = () => {
     const params = new URLSearchParams(location.search)
-    params.set(TABLE_STATE_URL_PARAM, `${encodeURIComponent(tableStateId)}`)
+    params.set(TABLE_STATE_URL_PARAM, tableStateId)
     return `${location.pathname}?${params.toString()}`
   }
 

--- a/frontend/src/components/TableView/TableView.tsx
+++ b/frontend/src/components/TableView/TableView.tsx
@@ -419,7 +419,11 @@ export const TableView = <T extends MRT_RowData>({
     )
   }
 
-  const buildTableStateUrl = () => `${location.pathname}?${TABLE_STATE_URL_PARAM}=${encodeURIComponent(tableStateId)}`
+  const buildTableStateUrl = () => {
+    const params = new URLSearchParams(location.search)
+    params.set(TABLE_STATE_URL_PARAM, `${encodeURIComponent(tableStateId)}`)
+    return `${location.pathname}?${params.toString()}`
+  }
 
   const loadStateFromUrl = <TState extends MRT_ColumnFiltersState | MRT_SortingState | MRT_PaginationState>(
     state: TableStateInUrl,

--- a/frontend/src/hooks/useSyncTabSearch.ts
+++ b/frontend/src/hooks/useSyncTabSearch.ts
@@ -18,15 +18,13 @@ export const useSyncTabSearch = (tab: number) => {
   }, [location.key, location.state])
 
   useEffect(() => {
-    const nextSearch = `?tab=${tab}`
-    if (location.search === nextSearch) {
-      return
-    }
+    const params = new URLSearchParams(location.search)
+    if (params.get('tab') === encodeURIComponent(tab)) return
 
     navigate(
       {
         pathname: location.pathname,
-        search: nextSearch,
+        search: `?tab=${tab}`,
       },
       {
         replace: true,

--- a/frontend/src/hooks/useSyncTabSearch.ts
+++ b/frontend/src/hooks/useSyncTabSearch.ts
@@ -19,7 +19,7 @@ export const useSyncTabSearch = (tab: number) => {
 
   useEffect(() => {
     const params = new URLSearchParams(location.search)
-    if (params.get('tab') === encodeURIComponent(tab)) return
+    if (params.get('tab') === String(tab)) return
 
     navigate(
       {


### PR DESCRIPTION
…s in url

See #1199 . The problem was that when switching to any tab with a TableView inside, `useSyncTabSearch` replaced the `tableState` query param with its `tab` param. Now whenever a tab is changed, all query params are cleared, and the `tableState` query param is added to the URL afterwards.